### PR TITLE
feat(config): add strongly-typed options for all services

### DIFF
--- a/src/Kursa.API/Program.cs
+++ b/src/Kursa.API/Program.cs
@@ -6,7 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddOpenApi();
 builder.Services.AddApplication();
-builder.Services.AddInfrastructure();
+builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/Kursa.API/appsettings.json
+++ b/src/Kursa.API/appsettings.json
@@ -2,8 +2,52 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=kursa;Username=kursa;Password=kursa_dev",
+    "Redis": "localhost:6379"
+  },
+  "Qdrant": {
+    "Host": "localhost",
+    "Port": 6334,
+    "ApiKey": ""
+  },
+  "MinIO": {
+    "Endpoint": "localhost:9000",
+    "AccessKey": "minioadmin",
+    "SecretKey": "minioadmin",
+    "UseSsl": false,
+    "BucketName": "kursa"
+  },
+  "Moodle": {
+    "ApiBaseUrl": ""
+  },
+  "Llm": {
+    "Provider": "openai",
+    "ApiKey": "",
+    "Model": "gpt-4o-mini",
+    "OllamaHost": "http://localhost:11434"
+  },
+  "MicrosoftGraph": {
+    "ClientId": "",
+    "TenantId": "",
+    "ClientSecret": ""
+  },
+  "Hangfire": {
+    "DashboardEnabled": true
+  },
+  "AudioProcessing": {
+    "WhisperUrl": "http://localhost:8001",
+    "PyannoteUrl": "http://localhost:8002"
+  },
+  "Oidc": {
+    "Authority": "",
+    "ClientId": "",
+    "ClientSecret": "",
+    "RequireHttpsMetadata": true
+  }
 }

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -1,11 +1,40 @@
+using Kursa.Infrastructure.Options;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Kursa.Infrastructure;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
+        services.AddOptions<QdrantOptions>()
+            .Bind(configuration.GetSection(QdrantOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<MinIOOptions>()
+            .Bind(configuration.GetSection(MinIOOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<MoodleOptions>()
+            .Bind(configuration.GetSection(MoodleOptions.SectionName));
+
+        services.AddOptions<LlmOptions>()
+            .Bind(configuration.GetSection(LlmOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<MicrosoftGraphOptions>()
+            .Bind(configuration.GetSection(MicrosoftGraphOptions.SectionName));
+
+        services.AddOptions<AudioProcessingOptions>()
+            .Bind(configuration.GetSection(AudioProcessingOptions.SectionName));
+
+        services.AddOptions<OidcOptions>()
+            .Bind(configuration.GetSection(OidcOptions.SectionName));
+
         return services;
     }
 }

--- a/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
+++ b/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
@@ -11,7 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Kursa.Infrastructure/Options/AudioProcessingOptions.cs
+++ b/src/Kursa.Infrastructure/Options/AudioProcessingOptions.cs
@@ -1,0 +1,10 @@
+namespace Kursa.Infrastructure.Options;
+
+public sealed class AudioProcessingOptions
+{
+    public const string SectionName = "AudioProcessing";
+
+    public string WhisperUrl { get; init; } = "http://localhost:8001";
+
+    public string PyannoteUrl { get; init; } = "http://localhost:8002";
+}

--- a/src/Kursa.Infrastructure/Options/LlmOptions.cs
+++ b/src/Kursa.Infrastructure/Options/LlmOptions.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Kursa.Infrastructure.Options;
+
+public sealed class LlmOptions
+{
+    public const string SectionName = "Llm";
+
+    [Required]
+    public required string Provider { get; init; }
+
+    public string ApiKey { get; init; } = string.Empty;
+
+    public string Model { get; init; } = "gpt-4o-mini";
+
+    public string OllamaHost { get; init; } = "http://localhost:11434";
+}

--- a/src/Kursa.Infrastructure/Options/MicrosoftGraphOptions.cs
+++ b/src/Kursa.Infrastructure/Options/MicrosoftGraphOptions.cs
@@ -1,0 +1,12 @@
+namespace Kursa.Infrastructure.Options;
+
+public sealed class MicrosoftGraphOptions
+{
+    public const string SectionName = "MicrosoftGraph";
+
+    public string ClientId { get; init; } = string.Empty;
+
+    public string TenantId { get; init; } = string.Empty;
+
+    public string ClientSecret { get; init; } = string.Empty;
+}

--- a/src/Kursa.Infrastructure/Options/MinIOOptions.cs
+++ b/src/Kursa.Infrastructure/Options/MinIOOptions.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Kursa.Infrastructure.Options;
+
+public sealed class MinIOOptions
+{
+    public const string SectionName = "MinIO";
+
+    [Required]
+    public required string Endpoint { get; init; }
+
+    [Required]
+    public required string AccessKey { get; init; }
+
+    [Required]
+    public required string SecretKey { get; init; }
+
+    public bool UseSsl { get; init; }
+
+    public string BucketName { get; init; } = "kursa";
+}

--- a/src/Kursa.Infrastructure/Options/MoodleOptions.cs
+++ b/src/Kursa.Infrastructure/Options/MoodleOptions.cs
@@ -1,0 +1,8 @@
+namespace Kursa.Infrastructure.Options;
+
+public sealed class MoodleOptions
+{
+    public const string SectionName = "Moodle";
+
+    public string ApiBaseUrl { get; init; } = string.Empty;
+}

--- a/src/Kursa.Infrastructure/Options/OidcOptions.cs
+++ b/src/Kursa.Infrastructure/Options/OidcOptions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Kursa.Infrastructure.Options;
+
+public sealed class OidcOptions
+{
+    public const string SectionName = "Oidc";
+
+    [Required]
+    public required string Authority { get; init; }
+
+    [Required]
+    public required string ClientId { get; init; }
+
+    public string ClientSecret { get; init; } = string.Empty;
+
+    public bool RequireHttpsMetadata { get; init; } = true;
+}

--- a/src/Kursa.Infrastructure/Options/QdrantOptions.cs
+++ b/src/Kursa.Infrastructure/Options/QdrantOptions.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Kursa.Infrastructure.Options;
+
+public sealed class QdrantOptions
+{
+    public const string SectionName = "Qdrant";
+
+    [Required]
+    public required string Host { get; init; }
+
+    public int Port { get; init; } = 6334;
+
+    public string ApiKey { get; init; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- Added all service configuration sections to `appsettings.json` (PostgreSQL, Redis, Qdrant, MinIO, Moodle, LLM, Microsoft Graph, Hangfire, AudioProcessing, OIDC)
- Created 7 strongly-typed options classes in `Infrastructure/Options/` with DataAnnotations validation
- Registered all options with `ValidateDataAnnotations()` and `ValidateOnStart()` for required services
- Updated `AddInfrastructure()` to accept `IConfiguration` parameter

Closes #28

## Test plan
- [x] `dotnet build Kursa.slnx` passes with 0 warnings, 0 errors
- [x] Options classes use `[Required]` for mandatory fields
- [x] Startup validation enabled for critical services (Qdrant, MinIO, LLM)