### PR TITLE
feat(data): set up PostgreSQL + EF Core with initial entities

### DIFF
--- a/src/Kursa.API/Kursa.API.csproj
+++ b/src/Kursa.API/Kursa.API.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kursa.Domain/Entities/BaseEntity.cs
+++ b/src/Kursa.Domain/Entities/BaseEntity.cs
@@ -1,0 +1,10 @@
+namespace Kursa.Domain.Entities;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Kursa.Domain/Entities/Content.cs
+++ b/src/Kursa.Domain/Entities/Content.cs
@@ -1,0 +1,26 @@
+using Kursa.Domain.Enums;
+
+namespace Kursa.Domain.Entities;
+
+public class Content : BaseEntity
+{
+    public required string Title { get; set; }
+
+    public string? Description { get; set; }
+
+    public ContentType Type { get; set; }
+
+    public string? Url { get; set; }
+
+    public string? FilePath { get; set; }
+
+    public int? MoodleContentId { get; set; }
+
+    public int SortOrder { get; set; }
+
+    public Guid ModuleId { get; set; }
+
+    public Module Module { get; set; } = null!;
+
+    public ICollection<PinnedContent> PinnedByUsers { get; init; } = new List<PinnedContent>();
+}

--- a/src/Kursa.Domain/Entities/Course.cs
+++ b/src/Kursa.Domain/Entities/Course.cs
@@ -1,0 +1,20 @@
+namespace Kursa.Domain.Entities;
+
+public class Course : BaseEntity
+{
+    public required string Name { get; set; }
+
+    public string? ShortName { get; set; }
+
+    public string? Summary { get; set; }
+
+    public int? MoodleCourseId { get; set; }
+
+    public string? ImageUrl { get; set; }
+
+    public bool IsVisible { get; set; } = true;
+
+    public ICollection<Module> Modules { get; init; } = new List<Module>();
+
+    public ICollection<User> Users { get; init; } = new List<User>();
+}

--- a/src/Kursa.Domain/Entities/Module.cs
+++ b/src/Kursa.Domain/Entities/Module.cs
@@ -1,0 +1,18 @@
+namespace Kursa.Domain.Entities;
+
+public class Module : BaseEntity
+{
+    public required string Name { get; set; }
+
+    public string? Description { get; set; }
+
+    public int SortOrder { get; set; }
+
+    public int? MoodleModuleId { get; set; }
+
+    public Guid CourseId { get; set; }
+
+    public Course Course { get; set; } = null!;
+
+    public ICollection<Content> Contents { get; init; } = new List<Content>();
+}

--- a/src/Kursa.Domain/Entities/PinnedContent.cs
+++ b/src/Kursa.Domain/Entities/PinnedContent.cs
@@ -1,0 +1,18 @@
+namespace Kursa.Domain.Entities;
+
+public class PinnedContent : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public Guid ContentId { get; set; }
+
+    public Content Content { get; set; } = null!;
+
+    public bool IsStarred { get; set; }
+
+    public bool IsIndexed { get; set; }
+
+    public string? Notes { get; set; }
+}

--- a/src/Kursa.Domain/Entities/User.cs
+++ b/src/Kursa.Domain/Entities/User.cs
@@ -1,0 +1,26 @@
+using Kursa.Domain.Enums;
+
+namespace Kursa.Domain.Entities;
+
+public class User : BaseEntity
+{
+    public required string ExternalId { get; init; }
+
+    public required string Email { get; set; }
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public UserRole Role { get; set; } = UserRole.Student;
+
+    public string? MoodleToken { get; set; }
+
+    public string? MoodleUrl { get; set; }
+
+    public bool OnboardingCompleted { get; set; }
+
+    public DateTime? LastLoginAt { get; set; }
+
+    public ICollection<Course> Courses { get; init; } = new List<Course>();
+
+    public ICollection<PinnedContent> PinnedContents { get; init; } = new List<PinnedContent>();
+}

--- a/src/Kursa.Domain/Enums/ContentType.cs
+++ b/src/Kursa.Domain/Enums/ContentType.cs
@@ -1,0 +1,13 @@
+namespace Kursa.Domain.Enums;
+
+public enum ContentType
+{
+    Document = 0,
+    Pdf = 1,
+    Html = 2,
+    Video = 3,
+    Audio = 4,
+    Link = 5,
+    Assignment = 6,
+    Quiz = 7
+}

--- a/src/Kursa.Domain/Enums/UserRole.cs
+++ b/src/Kursa.Domain/Enums/UserRole.cs
@@ -1,0 +1,8 @@
+namespace Kursa.Domain.Enums;
+
+public enum UserRole
+{
+    Student = 0,
+    Teacher = 1,
+    Admin = 2
+}

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,6 @@
 using Kursa.Infrastructure.Options;
+using Kursa.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +10,9 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
+
         services.AddOptions<QdrantOptions>()
             .Bind(configuration.GetSection(QdrantOptions.SectionName))
             .ValidateDataAnnotations()

--- a/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
+++ b/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
@@ -11,10 +11,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,35 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Infrastructure.Persistence;
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<User> Users => Set<User>();
+
+    public DbSet<Course> Courses => Set<Course>();
+
+    public DbSet<Module> Modules => Set<Module>();
+
+    public DbSet<Content> Contents => Set<Content>();
+
+    public DbSet<PinnedContent> PinnedContents => Set<PinnedContent>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+
+    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        foreach (var entry in ChangeTracker.Entries<BaseEntity>())
+        {
+            if (entry.State == EntityState.Modified)
+            {
+                entry.Entity.UpdatedAt = DateTime.UtcNow;
+            }
+        }
+
+        return base.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/Configurations/ContentConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/ContentConfiguration.cs
@@ -1,0 +1,20 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class ContentConfiguration : IEntityTypeConfiguration<Content>
+{
+    public void Configure(EntityTypeBuilder<Content> builder)
+    {
+        builder.HasKey(c => c.Id);
+
+        builder.HasIndex(c => c.MoodleContentId);
+
+        builder.Property(c => c.Title).IsRequired().HasMaxLength(512);
+        builder.Property(c => c.Description).HasMaxLength(4096);
+        builder.Property(c => c.Url).HasMaxLength(2048);
+        builder.Property(c => c.FilePath).HasMaxLength(1024);
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/Configurations/CourseConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/CourseConfiguration.cs
@@ -1,0 +1,25 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class CourseConfiguration : IEntityTypeConfiguration<Course>
+{
+    public void Configure(EntityTypeBuilder<Course> builder)
+    {
+        builder.HasKey(c => c.Id);
+
+        builder.HasIndex(c => c.MoodleCourseId);
+
+        builder.Property(c => c.Name).IsRequired().HasMaxLength(512);
+        builder.Property(c => c.ShortName).HasMaxLength(128);
+        builder.Property(c => c.Summary).HasMaxLength(4096);
+        builder.Property(c => c.ImageUrl).HasMaxLength(1024);
+
+        builder.HasMany(c => c.Modules)
+            .WithOne(m => m.Course)
+            .HasForeignKey(m => m.CourseId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/Configurations/ModuleConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/ModuleConfiguration.cs
@@ -1,0 +1,23 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class ModuleConfiguration : IEntityTypeConfiguration<Module>
+{
+    public void Configure(EntityTypeBuilder<Module> builder)
+    {
+        builder.HasKey(m => m.Id);
+
+        builder.HasIndex(m => m.MoodleModuleId);
+
+        builder.Property(m => m.Name).IsRequired().HasMaxLength(512);
+        builder.Property(m => m.Description).HasMaxLength(4096);
+
+        builder.HasMany(m => m.Contents)
+            .WithOne(c => c.Module)
+            .HasForeignKey(c => c.ModuleId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/Configurations/PinnedContentConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/PinnedContentConfiguration.cs
@@ -1,0 +1,27 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class PinnedContentConfiguration : IEntityTypeConfiguration<PinnedContent>
+{
+    public void Configure(EntityTypeBuilder<PinnedContent> builder)
+    {
+        builder.HasKey(pc => pc.Id);
+
+        builder.HasIndex(pc => new { pc.UserId, pc.ContentId }).IsUnique();
+
+        builder.Property(pc => pc.Notes).HasMaxLength(4096);
+
+        builder.HasOne(pc => pc.User)
+            .WithMany(u => u.PinnedContents)
+            .HasForeignKey(pc => pc.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(pc => pc.Content)
+            .WithMany(c => c.PinnedByUsers)
+            .HasForeignKey(pc => pc.ContentId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -1,0 +1,26 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.HasKey(u => u.Id);
+
+        builder.HasIndex(u => u.ExternalId).IsUnique();
+        builder.HasIndex(u => u.Email).IsUnique();
+
+        builder.Property(u => u.ExternalId).IsRequired().HasMaxLength(256);
+        builder.Property(u => u.Email).IsRequired().HasMaxLength(256);
+        builder.Property(u => u.DisplayName).HasMaxLength(256);
+        builder.Property(u => u.MoodleToken).HasMaxLength(512);
+        builder.Property(u => u.MoodleUrl).HasMaxLength(512);
+
+        builder.HasMany(u => u.Courses)
+            .WithMany(c => c.Users)
+            .UsingEntity("UserCourses");
+    }
+}


### PR DESCRIPTION
## Summary
- Created domain entities: `User`, `Course`, `Module`, `Content`, `PinnedContent` with `BaseEntity`
- Added enums: `UserRole`, `ContentType`
- Created `AppDbContext` with auto `UpdatedAt` tracking on save
- Added fluent entity configurations with proper indexes, constraints, and relationships
- Registered DbContext with Npgsql provider in DI
- Created `InitialCreate` migration

Closes #2

## Test plan
- [x] `dotnet build Kursa.slnx` — 0 warnings, 0 errors
- [x] `dotnet ef migrations` created successfully
- [x] Entity relationships: User↔Course (M:M), Course→Module (1:M), Module→Content (1:M), User↔Content via PinnedContent (M:M)