### PR TITLE
feat(cqrs): configure MediatR + CQRS with pipeline behaviors

### DIFF
--- a/src/Kursa.Application/Common/Behaviors/LoggingBehavior.cs
+++ b/src/Kursa.Application/Common/Behaviors/LoggingBehavior.cs
@@ -1,0 +1,25 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Application.Common.Behaviors;
+
+public sealed class LoggingBehavior<TRequest, TResponse>(ILogger<LoggingBehavior<TRequest, TResponse>> logger)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        string requestName = typeof(TRequest).Name;
+
+        logger.LogInformation("Handling {RequestName}", requestName);
+
+        TResponse response = await next(cancellationToken);
+
+        logger.LogInformation("Handled {RequestName}", requestName);
+
+        return response;
+    }
+}

--- a/src/Kursa.Application/Common/Behaviors/ValidationBehavior.cs
+++ b/src/Kursa.Application/Common/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using MediatR;
+
+namespace Kursa.Application.Common.Behaviors;
+
+public sealed class ValidationBehavior<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (!validators.Any())
+        {
+            return await next(cancellationToken);
+        }
+
+        var context = new ValidationContext<TRequest>(request);
+
+        var validationResults = await Task.WhenAll(
+            validators.Select(v => v.ValidateAsync(context, cancellationToken)));
+
+        var failures = validationResults
+            .SelectMany(r => r.Errors)
+            .Where(f => f is not null)
+            .ToList();
+
+        if (failures.Count != 0)
+        {
+            throw new ValidationException(failures);
+        }
+
+        return await next(cancellationToken);
+    }
+}

--- a/src/Kursa.Application/Common/Models/Result.cs
+++ b/src/Kursa.Application/Common/Models/Result.cs
@@ -1,0 +1,46 @@
+namespace Kursa.Application.Common.Models;
+
+public sealed class Result
+{
+    private Result(bool isSuccess, string? error)
+    {
+        IsSuccess = isSuccess;
+        Error = error;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public string? Error { get; }
+
+    public static Result Success() => new(true, null);
+
+    public static Result Failure(string error) => new(false, error);
+
+    public static Result<T> Success<T>(T value) => Result<T>.Success(value);
+
+    public static Result<T> Failure<T>(string error) => Result<T>.Failure(error);
+}
+
+public sealed class Result<T>
+{
+    private Result(bool isSuccess, T? value, string? error)
+    {
+        IsSuccess = isSuccess;
+        Value = value;
+        Error = error;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public T? Value { get; }
+
+    public string? Error { get; }
+
+    public static Result<T> Success(T value) => new(true, value, null);
+
+    public static Result<T> Failure(string error) => new(false, default, error);
+}

--- a/src/Kursa.Application/DependencyInjection.cs
+++ b/src/Kursa.Application/DependencyInjection.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using FluentValidation;
+using Kursa.Application.Common.Behaviors;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Kursa.Application;
@@ -6,6 +9,17 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+        Assembly assembly = typeof(DependencyInjection).Assembly;
+
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(assembly);
+            cfg.AddOpenBehavior(typeof(LoggingBehavior<,>));
+            cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
+        });
+
+        services.AddValidatorsFromAssembly(assembly);
+
         return services;
     }
 }

--- a/src/Kursa.Application/Kursa.Application.csproj
+++ b/src/Kursa.Application/Kursa.Application.csproj
@@ -11,7 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+    <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Added MediatR and FluentValidation packages to Application layer
- Created `Result<T>` wrapper type for command responses
- Created `ValidationBehavior` — auto-validates requests using FluentValidation
- Created `LoggingBehavior` — logs request handling lifecycle
- Registered MediatR with assembly scanning and pipeline behaviors in DI

Closes #3

## Test plan
- [x] `dotnet build Kursa.slnx` — 0 warnings, 0 errors
- [x] Pipeline behaviors registered as open generics
- [x] FluentValidation validators auto-discovered from assembly