### PR TITLE
feat(api): add global exception handler + Serilog logging

### DIFF
--- a/src/Kursa.API/Kursa.API.csproj
+++ b/src/Kursa.API/Kursa.API.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kursa.API/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Kursa.API/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,17 @@
+namespace Kursa.API.Middleware;
+
+public sealed class CorrelationIdMiddleware(RequestDelegate next)
+{
+    private const string CorrelationIdHeader = "X-Correlation-Id";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        string correlationId = context.Request.Headers[CorrelationIdHeader].FirstOrDefault()
+            ?? Guid.NewGuid().ToString();
+
+        context.Items["CorrelationId"] = correlationId;
+        context.Response.Headers[CorrelationIdHeader] = correlationId;
+
+        await next(context);
+    }
+}

--- a/src/Kursa.API/Middleware/GlobalExceptionHandler.cs
+++ b/src/Kursa.API/Middleware/GlobalExceptionHandler.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using FluentValidation;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Middleware;
+
+public sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        ProblemDetails problemDetails = exception switch
+        {
+            ValidationException validationException => new ProblemDetails
+            {
+                Status = (int)HttpStatusCode.BadRequest,
+                Title = "Validation Error",
+                Detail = string.Join("; ", validationException.Errors.Select(e => e.ErrorMessage)),
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1"
+            },
+            UnauthorizedAccessException => new ProblemDetails
+            {
+                Status = (int)HttpStatusCode.Forbidden,
+                Title = "Forbidden",
+                Detail = "You do not have permission to access this resource.",
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.5.4"
+            },
+            KeyNotFoundException => new ProblemDetails
+            {
+                Status = (int)HttpStatusCode.NotFound,
+                Title = "Not Found",
+                Detail = exception.Message,
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.5.5"
+            },
+            _ => new ProblemDetails
+            {
+                Status = (int)HttpStatusCode.InternalServerError,
+                Title = "Internal Server Error",
+                Detail = "An unexpected error occurred.",
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.6.1"
+            }
+        };
+
+        if (problemDetails.Status == (int)HttpStatusCode.InternalServerError)
+        {
+            logger.LogError(exception, "Unhandled exception: {Message}", exception.Message);
+        }
+        else
+        {
+            logger.LogWarning(exception, "Handled exception: {ExceptionType} - {Message}",
+                exception.GetType().Name, exception.Message);
+        }
+
+        string? correlationId = httpContext.Items["CorrelationId"]?.ToString();
+        if (correlationId is not null)
+        {
+            problemDetails.Extensions["correlationId"] = correlationId;
+        }
+
+        httpContext.Response.StatusCode = problemDetails.Status!.Value;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+}

--- a/src/Kursa.API/Program.cs
+++ b/src/Kursa.API/Program.cs
@@ -1,22 +1,48 @@
+using Kursa.API.Middleware;
 using Kursa.Application;
 using Kursa.Infrastructure;
+using Serilog;
 
-var builder = WebApplication.CreateBuilder(args);
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .CreateBootstrapLogger();
 
-builder.Services.AddControllers();
-builder.Services.AddOpenApi();
-builder.Services.AddApplication();
-builder.Services.AddInfrastructure(builder.Configuration);
-
-var app = builder.Build();
-
-if (app.Environment.IsDevelopment())
+try
 {
-    app.MapOpenApi();
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.Host.UseSerilog((context, configuration) =>
+        configuration.ReadFrom.Configuration(context.Configuration));
+
+    builder.Services.AddControllers();
+    builder.Services.AddOpenApi();
+    builder.Services.AddProblemDetails();
+    builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
+    builder.Services.AddApplication();
+    builder.Services.AddInfrastructure(builder.Configuration);
+
+    var app = builder.Build();
+
+    app.UseMiddleware<CorrelationIdMiddleware>();
+    app.UseExceptionHandler();
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.MapOpenApi();
+    }
+
+    app.UseSerilogRequestLogging();
+    app.UseHttpsRedirection();
+    app.UseAuthorization();
+    app.MapControllers();
+
+    app.Run();
 }
-
-app.UseHttpsRedirection();
-app.UseAuthorization();
-app.MapControllers();
-
-app.Run();
+catch (Exception ex) when (ex is not HostAbortedException)
+{
+    Log.Fatal(ex, "Application terminated unexpectedly");
+}
+finally
+{
+    Log.CloseAndFlush();
+}

--- a/src/Kursa.API/appsettings.json
+++ b/src/Kursa.API/appsettings.json
@@ -1,9 +1,20 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console"],
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning",
-      "Microsoft.EntityFrameworkCore": "Warning"
+      "Override": {
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      { "Name": "Console" }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName"],
+    "Properties": {
+      "Application": "Kursa.API"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## Summary
- Added `GlobalExceptionHandler` with ProblemDetails responses for ValidationException (400), UnauthorizedAccessException (403), KeyNotFoundException (404), and unhandled exceptions (500)
- Added `CorrelationIdMiddleware` for request tracking via X-Correlation-Id header
- Integrated Serilog with console sink and structured logging
- Added request logging pipeline via `UseSerilogRequestLogging()`

Closes #29

## Test plan
- [x] `dotnet build Kursa.slnx` — 0 warnings, 0 errors
- [x] Exception handler maps to correct HTTP status codes
- [x] Correlation ID propagated in response headers and ProblemDetails