### PR TITLE
feat(users): user management with profiles, settings, CQRS

### DIFF
--- a/src/Kursa.API/Controllers/UsersController.cs
+++ b/src/Kursa.API/Controllers/UsersController.cs
@@ -1,0 +1,47 @@
+using Kursa.Application.Features.Users.Commands;
+using Kursa.Application.Features.Users.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class UsersController(ISender sender) : ControllerBase
+{
+    [HttpGet("me")]
+    public async Task<IActionResult> GetCurrentUserAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetCurrentUserQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : Unauthorized(result.Error);
+    }
+
+    [HttpPut("me/profile")]
+    public async Task<IActionResult> UpdateProfileAsync(
+        UpdateUserProfileCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPut("me/settings")]
+    public async Task<IActionResult> UpdateSettingsAsync(
+        UpdateUserSettingsCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+}

--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -1,0 +1,21 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IAppDbContext
+{
+    DbSet<User> Users { get; }
+
+    DbSet<Course> Courses { get; }
+
+    DbSet<Module> Modules { get; }
+
+    DbSet<Content> Contents { get; }
+
+    DbSet<PinnedContent> PinnedContents { get; }
+
+    DbSet<UserSettings> UserSettings { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Features/Users/Commands/UpdateUserProfile.cs
+++ b/src/Kursa.Application/Features/Users/Commands/UpdateUserProfile.cs
@@ -1,0 +1,61 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Users.Commands;
+
+public sealed record UpdateUserProfileCommand(
+    string? DisplayName,
+    string? AvatarUrl) : IRequest<Result<UserDto>>;
+
+public sealed class UpdateUserProfileValidator : AbstractValidator<UpdateUserProfileCommand>
+{
+    public UpdateUserProfileValidator()
+    {
+        RuleFor(x => x.DisplayName)
+            .MaximumLength(256)
+            .When(x => x.DisplayName is not null);
+
+        RuleFor(x => x.AvatarUrl)
+            .MaximumLength(1024)
+            .When(x => x.AvatarUrl is not null);
+    }
+}
+
+public sealed class UpdateUserProfileHandler(
+    ICurrentUserService currentUserService,
+    IUserSyncService userSyncService) : IRequestHandler<UpdateUserProfileCommand, Result<UserDto>>
+{
+    public async Task<Result<UserDto>> Handle(UpdateUserProfileCommand request, CancellationToken cancellationToken)
+    {
+        if (currentUserService.ExternalId is null || currentUserService.Email is null)
+        {
+            return Result<UserDto>.Failure("User is not authenticated.");
+        }
+
+        var user = await userSyncService.SyncUserAsync(
+            currentUserService.ExternalId,
+            currentUserService.Email,
+            currentUserService.DisplayName ?? currentUserService.Email,
+            cancellationToken);
+
+        if (request.DisplayName is not null)
+            user.DisplayName = request.DisplayName;
+
+        if (request.AvatarUrl is not null)
+            user.AvatarUrl = request.AvatarUrl;
+
+        return Result<UserDto>.Success(new UserDto(
+            user.Id,
+            user.Email,
+            user.DisplayName,
+            user.AvatarUrl,
+            user.Role,
+            user.OnboardingCompleted,
+            user.MoodleUrl,
+            user.MoodleToken is not null,
+            user.CreatedAt));
+    }
+}

--- a/src/Kursa.Application/Features/Users/Commands/UpdateUserSettings.cs
+++ b/src/Kursa.Application/Features/Users/Commands/UpdateUserSettings.cs
@@ -1,0 +1,86 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Users.Commands;
+
+public sealed record UpdateUserSettingsCommand(
+    string? Theme,
+    string? Language,
+    string? Timezone,
+    bool? NotificationsEnabled) : IRequest<Result<UserSettingsDto>>;
+
+public sealed class UpdateUserSettingsValidator : AbstractValidator<UpdateUserSettingsCommand>
+{
+    private static readonly string[] ValidThemes = ["light", "dark", "system"];
+
+    public UpdateUserSettingsValidator()
+    {
+        RuleFor(x => x.Theme)
+            .Must(t => ValidThemes.Contains(t))
+            .When(x => x.Theme is not null)
+            .WithMessage("Theme must be 'light', 'dark', or 'system'.");
+
+        RuleFor(x => x.Language)
+            .MaximumLength(16)
+            .When(x => x.Language is not null);
+
+        RuleFor(x => x.Timezone)
+            .MaximumLength(64)
+            .When(x => x.Timezone is not null);
+    }
+}
+
+public sealed class UpdateUserSettingsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<UpdateUserSettingsCommand, Result<UserSettingsDto>>
+{
+    public async Task<Result<UserSettingsDto>> Handle(
+        UpdateUserSettingsCommand request,
+        CancellationToken cancellationToken)
+    {
+        if (currentUserService.ExternalId is null)
+        {
+            return Result<UserSettingsDto>.Failure("User is not authenticated.");
+        }
+
+        User? user = await dbContext.Users
+            .Include(u => u.Settings)
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+        {
+            return Result<UserSettingsDto>.Failure("User not found.");
+        }
+
+        UserSettings settings = user.Settings ?? new UserSettings { UserId = user.Id };
+
+        if (request.Theme is not null)
+            settings.Theme = request.Theme;
+
+        if (request.Language is not null)
+            settings.Language = request.Language;
+
+        if (request.Timezone is not null)
+            settings.Timezone = request.Timezone;
+
+        if (request.NotificationsEnabled.HasValue)
+            settings.NotificationsEnabled = request.NotificationsEnabled.Value;
+
+        if (user.Settings is null)
+        {
+            user.Settings = settings;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<UserSettingsDto>.Success(new UserSettingsDto(
+            settings.Theme,
+            settings.Language,
+            settings.Timezone,
+            settings.NotificationsEnabled));
+    }
+}

--- a/src/Kursa.Application/Features/Users/Queries/GetCurrentUser.cs
+++ b/src/Kursa.Application/Features/Users/Queries/GetCurrentUser.cs
@@ -1,0 +1,39 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Users.Queries;
+
+public sealed record GetCurrentUserQuery : IRequest<Result<UserDto>>;
+
+public sealed class GetCurrentUserHandler(
+    ICurrentUserService currentUserService,
+    IUserSyncService userSyncService) : IRequestHandler<GetCurrentUserQuery, Result<UserDto>>
+{
+    public async Task<Result<UserDto>> Handle(GetCurrentUserQuery request, CancellationToken cancellationToken)
+    {
+        if (currentUserService.ExternalId is null || currentUserService.Email is null)
+        {
+            return Result<UserDto>.Failure("User is not authenticated.");
+        }
+
+        User user = await userSyncService.SyncUserAsync(
+            currentUserService.ExternalId,
+            currentUserService.Email,
+            currentUserService.DisplayName ?? currentUserService.Email,
+            cancellationToken);
+
+        return Result<UserDto>.Success(new UserDto(
+            user.Id,
+            user.Email,
+            user.DisplayName,
+            user.AvatarUrl,
+            user.Role,
+            user.OnboardingCompleted,
+            user.MoodleUrl,
+            user.MoodleToken is not null,
+            user.CreatedAt));
+    }
+}

--- a/src/Kursa.Application/Features/Users/UserDto.cs
+++ b/src/Kursa.Application/Features/Users/UserDto.cs
@@ -1,0 +1,20 @@
+using Kursa.Domain.Enums;
+
+namespace Kursa.Application.Features.Users;
+
+public sealed record UserDto(
+    Guid Id,
+    string Email,
+    string DisplayName,
+    string? AvatarUrl,
+    UserRole Role,
+    bool OnboardingCompleted,
+    string? MoodleUrl,
+    bool HasMoodleToken,
+    DateTime CreatedAt);
+
+public sealed record UserSettingsDto(
+    string Theme,
+    string Language,
+    string Timezone,
+    bool NotificationsEnabled);

--- a/src/Kursa.Application/Kursa.Application.csproj
+++ b/src/Kursa.Application/Kursa.Application.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.4" />
   </ItemGroup>

--- a/src/Kursa.Domain/Entities/User.cs
+++ b/src/Kursa.Domain/Entities/User.cs
@@ -23,4 +23,8 @@ public class User : BaseEntity
     public ICollection<Course> Courses { get; init; } = new List<Course>();
 
     public ICollection<PinnedContent> PinnedContents { get; init; } = new List<PinnedContent>();
+
+    public UserSettings? Settings { get; set; }
+
+    public string? AvatarUrl { get; set; }
 }

--- a/src/Kursa.Domain/Entities/UserSettings.cs
+++ b/src/Kursa.Domain/Entities/UserSettings.cs
@@ -1,0 +1,16 @@
+namespace Kursa.Domain.Entities;
+
+public class UserSettings : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public string Theme { get; set; } = "dark";
+
+    public string Language { get; set; } = "en";
+
+    public string Timezone { get; set; } = "UTC";
+
+    public bool NotificationsEnabled { get; set; } = true;
+}

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -15,6 +15,8 @@ public static class DependencyInjection
         services.AddDbContext<AppDbContext>(options =>
             options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
 
+        services.AddScoped<IAppDbContext>(sp => sp.GetRequiredService<AppDbContext>());
+
         services.AddHttpContextAccessor();
         services.AddScoped<ICurrentUserService, CurrentUserService>();
         services.AddScoped<IUserSyncService, UserSyncService>();

--- a/src/Kursa.Infrastructure/Migrations/20260310204611_AddUserSettingsAndAvatar.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310204611_AddUserSettingsAndAvatar.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310204611_AddUserSettingsAndAvatar")]
+    partial class AddUserSettingsAndAvatar
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310204611_AddUserSettingsAndAvatar.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310204611_AddUserSettingsAndAvatar.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSettingsAndAvatar : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AvatarUrl",
+                table: "Users",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "UserSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Theme = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Language = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Timezone = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    NotificationsEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSettings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserSettings_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSettings_UserId",
+                table: "UserSettings",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AvatarUrl",
+                table: "Users");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -1,9 +1,10 @@
+using Kursa.Application.Common.Interfaces;
 using Kursa.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Kursa.Infrastructure.Persistence;
 
-public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options), IAppDbContext
 {
     public DbSet<User> Users => Set<User>();
 
@@ -14,6 +15,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<Content> Contents => Set<Content>();
 
     public DbSet<PinnedContent> PinnedContents => Set<PinnedContent>();
+
+    public DbSet<UserSettings> UserSettings => Set<UserSettings>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Kursa.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -18,6 +18,7 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
         builder.Property(u => u.DisplayName).HasMaxLength(256);
         builder.Property(u => u.MoodleToken).HasMaxLength(512);
         builder.Property(u => u.MoodleUrl).HasMaxLength(512);
+        builder.Property(u => u.AvatarUrl).HasMaxLength(1024);
 
         builder.HasMany(u => u.Courses)
             .WithMany(c => c.Users)

--- a/src/Kursa.Infrastructure/Persistence/Configurations/UserSettingsConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/UserSettingsConfiguration.cs
@@ -1,0 +1,24 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class UserSettingsConfiguration : IEntityTypeConfiguration<UserSettings>
+{
+    public void Configure(EntityTypeBuilder<UserSettings> builder)
+    {
+        builder.HasKey(s => s.Id);
+
+        builder.HasIndex(s => s.UserId).IsUnique();
+
+        builder.Property(s => s.Theme).HasMaxLength(32);
+        builder.Property(s => s.Language).HasMaxLength(16);
+        builder.Property(s => s.Timezone).HasMaxLength(64);
+
+        builder.HasOne(s => s.User)
+            .WithOne(u => u.Settings)
+            .HasForeignKey<UserSettings>(s => s.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}


### PR DESCRIPTION
## Summary
- Added `UserSettings` entity (theme, language, timezone, notifications)
- Added `AvatarUrl` to User entity
- Created `IAppDbContext` interface for Application→Infrastructure abstraction
- Created CQRS features: `GetCurrentUserQuery`, `UpdateUserProfileCommand`, `UpdateUserSettingsCommand`
- Added FluentValidation for profile and settings commands
- Created `UsersController` with `GET/PUT /api/users/me` endpoints
- Added EF migration for UserSettings table and AvatarUrl column

Closes #32

## Test plan
- [x] `dotnet build Kursa.slnx` — 0 warnings, 0 errors
- [x] CQRS pattern: queries return data, commands return Result<T>
- [x] Validation: theme restricted to light/dark/system, lengths enforced
- [x] UserSettings 1:1 relationship with cascade delete