### PR TITLE
feat(moodle): Moodle token linking per user

### DIFF
--- a/src/Kursa.API/Controllers/MoodleController.cs
+++ b/src/Kursa.API/Controllers/MoodleController.cs
@@ -1,0 +1,45 @@
+using Kursa.Application.Features.Moodle.Commands;
+using Kursa.Application.Features.Moodle.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class MoodleController(ISender sender) : ControllerBase
+{
+    [HttpGet("status")]
+    public async Task<IActionResult> GetConnectionStatusAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetMoodleConnectionStatusQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("link")]
+    public async Task<IActionResult> LinkTokenAsync(
+        LinkMoodleTokenCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Ok()
+            : BadRequest(result.Error);
+    }
+
+    [HttpDelete("link")]
+    public async Task<IActionResult> UnlinkTokenAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new UnlinkMoodleTokenCommand(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok()
+            : BadRequest(result.Error);
+    }
+}

--- a/src/Kursa.Application/Features/Moodle/Commands/LinkMoodleToken.cs
+++ b/src/Kursa.Application/Features/Moodle/Commands/LinkMoodleToken.cs
@@ -1,0 +1,55 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Commands;
+
+public sealed record LinkMoodleTokenCommand(
+    string MoodleUrl,
+    string Token) : IRequest<Result>;
+
+public sealed class LinkMoodleTokenValidator : AbstractValidator<LinkMoodleTokenCommand>
+{
+    public LinkMoodleTokenValidator()
+    {
+        RuleFor(x => x.MoodleUrl)
+            .NotEmpty()
+            .MaximumLength(512)
+            .Must(url => Uri.TryCreate(url, UriKind.Absolute, out _))
+            .WithMessage("Moodle URL must be a valid absolute URL.");
+
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .MaximumLength(512);
+    }
+}
+
+public sealed class LinkMoodleTokenHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<LinkMoodleTokenCommand, Result>
+{
+    public async Task<Result> Handle(LinkMoodleTokenCommand request, CancellationToken cancellationToken)
+    {
+        if (currentUserService.ExternalId is null)
+        {
+            return Result.Failure("User is not authenticated.");
+        }
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+        {
+            return Result.Failure("User not found.");
+        }
+
+        user.MoodleUrl = request.MoodleUrl.TrimEnd('/');
+        user.MoodleToken = request.Token;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Kursa.Application/Features/Moodle/Commands/UnlinkMoodleToken.cs
+++ b/src/Kursa.Application/Features/Moodle/Commands/UnlinkMoodleToken.cs
@@ -1,0 +1,36 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Commands;
+
+public sealed record UnlinkMoodleTokenCommand : IRequest<Result>;
+
+public sealed class UnlinkMoodleTokenHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<UnlinkMoodleTokenCommand, Result>
+{
+    public async Task<Result> Handle(UnlinkMoodleTokenCommand request, CancellationToken cancellationToken)
+    {
+        if (currentUserService.ExternalId is null)
+        {
+            return Result.Failure("User is not authenticated.");
+        }
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+        {
+            return Result.Failure("User not found.");
+        }
+
+        user.MoodleToken = null;
+        user.MoodleUrl = null;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetMoodleConnectionStatus.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetMoodleConnectionStatus.cs
@@ -1,0 +1,40 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record MoodleConnectionStatusDto(
+    bool IsConnected,
+    string? MoodleUrl);
+
+public sealed record GetMoodleConnectionStatusQuery : IRequest<Result<MoodleConnectionStatusDto>>;
+
+public sealed class GetMoodleConnectionStatusHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetMoodleConnectionStatusQuery, Result<MoodleConnectionStatusDto>>
+{
+    public async Task<Result<MoodleConnectionStatusDto>> Handle(
+        GetMoodleConnectionStatusQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (currentUserService.ExternalId is null)
+        {
+            return Result<MoodleConnectionStatusDto>.Failure("User is not authenticated.");
+        }
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+        {
+            return Result<MoodleConnectionStatusDto>.Failure("User not found.");
+        }
+
+        return Result<MoodleConnectionStatusDto>.Success(new MoodleConnectionStatusDto(
+            user.MoodleToken is not null,
+            user.MoodleUrl));
+    }
+}


### PR DESCRIPTION
## Summary
- Created `LinkMoodleTokenCommand` with URL + token validation
- Created `UnlinkMoodleTokenCommand` to remove token
- Created `GetMoodleConnectionStatusQuery` for connection status check
- Added `MoodleController` with POST/DELETE `/api/moodle/link` and GET `/api/moodle/status`

Closes #33

## Test plan
- [x] `dotnet build Kursa.slnx` — 0 warnings, 0 errors
- [x] Moodle URL validated as absolute URI
- [x] Token stored on User entity (MoodleToken/MoodleUrl fields)
- [x] Unlink clears both token and URL