### PR TITLE
feat(moodle): Moodle proxy service with Redis caching and course UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ coverage/
 *.tmp
 *.bak
 *.pid
+*.png

--- a/src/Kursa.API/Controllers/MoodleController.cs
+++ b/src/Kursa.API/Controllers/MoodleController.cs
@@ -42,4 +42,24 @@ public class MoodleController(ISender sender) : ControllerBase
             ? Ok()
             : BadRequest(result.Error);
     }
+
+    [HttpGet("courses")]
+    public async Task<IActionResult> GetCoursesAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetEnrolledCoursesQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("courses/{courseId:int}/content")]
+    public async Task<IActionResult> GetCourseContentAsync(int courseId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetCourseContentQuery(courseId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
 }

--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -1,0 +1,15 @@
+using Kursa.Application.Features.Moodle.Models;
+
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IMoodleService
+{
+    Task<IReadOnlyList<MoodleCourseDto>> GetEnrolledCoursesAsync(
+        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MoodleCourseSectionDto>> GetCourseContentAsync(
+        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default);
+
+    Task<MoodleSiteInfoDto> GetSiteInfoAsync(
+        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Features/Moodle/Models/MoodleDtos.cs
+++ b/src/Kursa.Application/Features/Moodle/Models/MoodleDtos.cs
@@ -1,0 +1,159 @@
+using System.Text.Json.Serialization;
+
+namespace Kursa.Application.Features.Moodle.Models;
+
+/// <summary>
+/// Represents a Moodle course returned by core_enrol_get_users_courses.
+/// </summary>
+public sealed record MoodleCourseDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("shortname")]
+    public string ShortName { get; init; } = string.Empty;
+
+    [JsonPropertyName("fullname")]
+    public string FullName { get; init; } = string.Empty;
+
+    [JsonPropertyName("summary")]
+    public string Summary { get; init; } = string.Empty;
+
+    [JsonPropertyName("startdate")]
+    public long StartDate { get; init; }
+
+    [JsonPropertyName("enddate")]
+    public long EndDate { get; init; }
+
+    [JsonPropertyName("visible")]
+    public int Visible { get; init; } = 1;
+
+    [JsonPropertyName("courseimage")]
+    public string? CourseImage { get; init; }
+
+    [JsonPropertyName("progress")]
+    public double? Progress { get; init; }
+
+    [JsonPropertyName("completed")]
+    public bool? Completed { get; init; }
+
+    [JsonPropertyName("category")]
+    public int Category { get; init; }
+}
+
+/// <summary>
+/// Represents a course section returned by core_course_get_contents.
+/// </summary>
+public sealed record MoodleCourseSectionDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("summary")]
+    public string Summary { get; init; } = string.Empty;
+
+    [JsonPropertyName("section")]
+    public int Section { get; init; }
+
+    [JsonPropertyName("visible")]
+    public int Visible { get; init; } = 1;
+
+    [JsonPropertyName("modules")]
+    public IReadOnlyList<MoodleModuleDto> Modules { get; init; } = [];
+}
+
+/// <summary>
+/// Represents a module/activity within a course section.
+/// </summary>
+public sealed record MoodleModuleDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("modname")]
+    public string ModName { get; init; } = string.Empty;
+
+    [JsonPropertyName("modplural")]
+    public string? ModPlural { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("visible")]
+    public int Visible { get; init; } = 1;
+
+    [JsonPropertyName("contents")]
+    public IReadOnlyList<MoodleContentDto>? Contents { get; init; }
+}
+
+/// <summary>
+/// Represents a content file/resource within a module.
+/// </summary>
+public sealed record MoodleContentDto
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = string.Empty;
+
+    [JsonPropertyName("filename")]
+    public string FileName { get; init; } = string.Empty;
+
+    [JsonPropertyName("filepath")]
+    public string? FilePath { get; init; }
+
+    [JsonPropertyName("filesize")]
+    public long FileSize { get; init; }
+
+    [JsonPropertyName("fileurl")]
+    public string? FileUrl { get; init; }
+
+    [JsonPropertyName("timecreated")]
+    public long TimeCreated { get; init; }
+
+    [JsonPropertyName("timemodified")]
+    public long TimeModified { get; init; }
+
+    [JsonPropertyName("mimetype")]
+    public string? MimeType { get; init; }
+}
+
+/// <summary>
+/// Represents Moodle site info returned by core_webservice_get_site_info.
+/// </summary>
+public sealed record MoodleSiteInfoDto
+{
+    [JsonPropertyName("sitename")]
+    public string SiteName { get; init; } = string.Empty;
+
+    [JsonPropertyName("username")]
+    public string Username { get; init; } = string.Empty;
+
+    [JsonPropertyName("firstname")]
+    public string FirstName { get; init; } = string.Empty;
+
+    [JsonPropertyName("lastname")]
+    public string LastName { get; init; } = string.Empty;
+
+    [JsonPropertyName("fullname")]
+    public string FullName { get; init; } = string.Empty;
+
+    [JsonPropertyName("userid")]
+    public int UserId { get; init; }
+
+    [JsonPropertyName("siteurl")]
+    public string SiteUrl { get; init; } = string.Empty;
+
+    [JsonPropertyName("userpictureurl")]
+    public string? UserPictureUrl { get; init; }
+
+    [JsonPropertyName("lang")]
+    public string? Language { get; init; }
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetCourseContent.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetCourseContent.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record GetCourseContentQuery(int MoodleCourseId) : IRequest<Result<IReadOnlyList<MoodleCourseSectionDto>>>;
+
+public sealed class GetCourseContentValidator : AbstractValidator<GetCourseContentQuery>
+{
+    public GetCourseContentValidator()
+    {
+        RuleFor(x => x.MoodleCourseId).GreaterThan(0).WithMessage("Course ID must be positive.");
+    }
+}
+
+public sealed class GetCourseContentHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<GetCourseContentQuery, Result<IReadOnlyList<MoodleCourseSectionDto>>>
+{
+    public async Task<Result<IReadOnlyList<MoodleCourseSectionDto>>> Handle(
+        GetCourseContentQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<MoodleCourseSectionDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<MoodleCourseSectionDto>>.Failure("User not found.");
+
+        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+            return Result<IReadOnlyList<MoodleCourseSectionDto>>.Failure("Moodle account is not linked.");
+
+        var sections = await moodleService.GetCourseContentAsync(
+            user.MoodleUrl, user.MoodleToken, request.MoodleCourseId, cancellationToken);
+
+        return Result<IReadOnlyList<MoodleCourseSectionDto>>.Success(sections);
+    }
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetEnrolledCourses.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetEnrolledCourses.cs
@@ -1,0 +1,37 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record GetEnrolledCoursesQuery : IRequest<Result<IReadOnlyList<MoodleCourseDto>>>;
+
+public sealed class GetEnrolledCoursesHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<GetEnrolledCoursesQuery, Result<IReadOnlyList<MoodleCourseDto>>>
+{
+    public async Task<Result<IReadOnlyList<MoodleCourseDto>>> Handle(
+        GetEnrolledCoursesQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<MoodleCourseDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<MoodleCourseDto>>.Failure("User not found.");
+
+        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+            return Result<IReadOnlyList<MoodleCourseDto>>.Failure("Moodle account is not linked.");
+
+        var courses = await moodleService.GetEnrolledCoursesAsync(
+            user.MoodleUrl, user.MoodleToken, cancellationToken);
+
+        return Result<IReadOnlyList<MoodleCourseDto>>.Success(courses);
+    }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -16,6 +16,16 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/dashboard/dashboard.component').then((m) => m.DashboardComponent),
       },
+      {
+        path: 'courses',
+        loadComponent: () =>
+          import('./features/courses/courses.component').then((m) => m.CoursesComponent),
+      },
+      {
+        path: 'courses/:courseId',
+        loadComponent: () =>
+          import('./features/courses/course-detail.component').then((m) => m.CourseDetailComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/moodle.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/moodle.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface MoodleCourse {
+  id: number;
+  shortName: string;
+  fullName: string;
+  summary: string;
+  startDate: number;
+  endDate: number;
+  visible: number;
+  courseImage: string | null;
+  progress: number | null;
+  completed: boolean | null;
+  category: number;
+}
+
+export interface MoodleCourseSection {
+  id: number;
+  name: string;
+  summary: string;
+  section: number;
+  visible: number;
+  modules: MoodleModule[];
+}
+
+export interface MoodleModule {
+  id: number;
+  name: string;
+  modName: string;
+  modPlural: string | null;
+  description: string | null;
+  url: string | null;
+  visible: number;
+  contents: MoodleContent[] | null;
+}
+
+export interface MoodleContent {
+  type: string;
+  fileName: string;
+  filePath: string | null;
+  fileSize: number;
+  fileUrl: string | null;
+  timeCreated: number;
+  timeModified: number;
+  mimeType: string | null;
+}
+
+export interface MoodleConnectionStatus {
+  isConnected: boolean;
+  moodleUrl: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MoodleService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/moodle';
+
+  getConnectionStatus(): Observable<MoodleConnectionStatus> {
+    return this.http.get<MoodleConnectionStatus>(`${this.baseUrl}/status`);
+  }
+
+  getEnrolledCourses(): Observable<MoodleCourse[]> {
+    return this.http.get<MoodleCourse[]>(`${this.baseUrl}/courses`);
+  }
+
+  getCourseContent(courseId: number): Observable<MoodleCourseSection[]> {
+    return this.http.get<MoodleCourseSection[]>(`${this.baseUrl}/courses/${courseId}/content`);
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
+++ b/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
@@ -1,0 +1,111 @@
+import { ChangeDetectionStrategy, Component, inject, input, signal, OnInit } from '@angular/core';
+import { MoodleCourseSection, MoodleService } from '../../core/services/moodle.service';
+import { DecimalPipe } from '@angular/common';
+
+@Component({
+  selector: 'app-course-detail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DecimalPipe],
+  template: `
+    <div class="space-y-6">
+      <div class="flex items-center gap-3">
+        <a href="/courses" class="text-muted-foreground hover:text-foreground">
+          <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+          </svg>
+        </a>
+        <h1 class="text-2xl font-bold text-foreground">Course Content</h1>
+      </div>
+
+      @if (loading()) {
+        <div class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+          <span class="ml-3 text-muted-foreground">Loading course content...</span>
+        </div>
+      } @else if (error()) {
+        <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-6">
+          <h2 class="text-lg font-semibold text-destructive">Unable to load content</h2>
+          <p class="mt-2 text-sm text-muted-foreground">{{ error() }}</p>
+        </div>
+      } @else {
+        @for (section of sections(); track section.id) {
+          <div class="rounded-lg border border-border bg-card">
+            <div class="border-b border-border p-4">
+              <h2 class="font-semibold text-foreground">{{ section.name }}</h2>
+              @if (section.summary) {
+                <p class="mt-1 text-sm text-muted-foreground" [innerHTML]="section.summary"></p>
+              }
+            </div>
+
+            @if (section.modules.length > 0) {
+              <ul class="divide-y divide-border">
+                @for (mod of section.modules; track mod.id) {
+                  <li class="flex items-center gap-3 p-4 hover:bg-accent">
+                    <div class="flex h-8 w-8 items-center justify-center rounded bg-muted text-xs font-medium text-muted-foreground uppercase">
+                      {{ mod.modName.slice(0, 3) }}
+                    </div>
+                    <div class="min-w-0 flex-1">
+                      <p class="font-medium text-foreground">{{ mod.name }}</p>
+                      @if (mod.contents && mod.contents.length > 0) {
+                        <p class="text-xs text-muted-foreground">
+                          {{ mod.contents.length }} file{{ mod.contents.length === 1 ? '' : 's' }}
+                          @if (totalFileSize(mod.contents) > 0) {
+                            · {{ totalFileSize(mod.contents) | number:'1.0-1' }} KB
+                          }
+                        </p>
+                      }
+                    </div>
+                    @if (mod.url) {
+                      <a
+                        [href]="mod.url"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-sm text-primary hover:underline"
+                      >
+                        Open
+                      </a>
+                    }
+                  </li>
+                }
+              </ul>
+            } @else {
+              <p class="p-4 text-sm text-muted-foreground">No activities in this section.</p>
+            }
+          </div>
+        }
+
+        @if (sections().length === 0) {
+          <div class="rounded-lg border border-border bg-card p-8 text-center">
+            <p class="text-muted-foreground">No content found for this course.</p>
+          </div>
+        }
+      }
+    </div>
+  `,
+})
+export class CourseDetailComponent implements OnInit {
+  private readonly moodleService = inject(MoodleService);
+
+  readonly courseId = input.required<number>();
+
+  readonly sections = signal<MoodleCourseSection[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.moodleService.getCourseContent(this.courseId()).subscribe({
+      next: (sections) => {
+        this.sections.set(sections);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set(err.error ?? 'Failed to load course content.');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  totalFileSize(contents: { fileSize: number }[]): number {
+    return contents.reduce((sum, c) => sum + c.fileSize, 0) / 1024;
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/courses/courses.component.ts
+++ b/src/Kursa.Frontend/src/app/features/courses/courses.component.ts
@@ -1,0 +1,98 @@
+import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { MoodleCourse, MoodleService } from '../../core/services/moodle.service';
+
+@Component({
+  selector: 'app-courses',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, DecimalPipe],
+  template: `
+    <div class="space-y-6">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-bold text-foreground">Courses</h1>
+      </div>
+
+      @if (loading()) {
+        <div class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+          <span class="ml-3 text-muted-foreground">Loading courses...</span>
+        </div>
+      } @else if (error()) {
+        <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-6">
+          <h2 class="text-lg font-semibold text-destructive">Unable to load courses</h2>
+          <p class="mt-2 text-sm text-muted-foreground">{{ error() }}</p>
+          <button
+            (click)="loadCourses()"
+            class="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Retry
+          </button>
+        </div>
+      } @else if (courses().length === 0) {
+        <div class="rounded-lg border border-border bg-card p-8 text-center">
+          <svg class="mx-auto h-12 w-12 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+          </svg>
+          <h2 class="mt-4 text-lg font-semibold text-foreground">No courses found</h2>
+          <p class="mt-2 text-sm text-muted-foreground">
+            Make sure your Moodle account is linked in Settings.
+          </p>
+        </div>
+      } @else {
+        <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          @for (course of courses(); track course.id) {
+            <a
+              [routerLink]="['/courses', course.id]"
+              class="group rounded-lg border border-border bg-card p-6 transition-colors hover:border-primary/50 hover:bg-accent"
+            >
+              <h3 class="font-semibold text-foreground group-hover:text-primary">{{ course.fullName }}</h3>
+              <p class="mt-1 text-sm text-muted-foreground">{{ course.shortName }}</p>
+              @if (course.progress !== null && course.progress !== undefined) {
+                <div class="mt-4">
+                  <div class="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Progress</span>
+                    <span>{{ course.progress | number:'1.0-0' }}%</span>
+                  </div>
+                  <div class="mt-1 h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      class="h-full rounded-full bg-primary transition-all"
+                      [style.width.%]="course.progress"
+                    ></div>
+                  </div>
+                </div>
+              }
+            </a>
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class CoursesComponent implements OnInit {
+  private readonly moodleService = inject(MoodleService);
+
+  readonly courses = signal<MoodleCourse[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.loadCourses();
+  }
+
+  loadCourses(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.moodleService.getEnrolledCourses().subscribe({
+      next: (courses) => {
+        this.courses.set(courses);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set(err.error ?? 'Failed to load courses. Please check your Moodle connection.');
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -21,6 +21,18 @@ public static class DependencyInjection
         services.AddScoped<ICurrentUserService, CurrentUserService>();
         services.AddScoped<IUserSyncService, UserSyncService>();
 
+        // Redis distributed cache
+        string redisConnection = configuration.GetConnectionString("Redis") ?? "localhost:6379";
+        services.AddStackExchangeRedisCache(options =>
+        {
+            options.Configuration = redisConnection;
+            options.InstanceName = "Kursa:";
+        });
+
+        // HTTP client for Moodle proxy
+        services.AddHttpClient("Moodle");
+        services.AddScoped<IMoodleService, MoodleService>();
+
         services.AddOptions<QdrantOptions>()
             .Bind(configuration.GetSection(QdrantOptions.SectionName))
             .ValidateDataAnnotations()

--- a/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
+++ b/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Features.Moodle.Models;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class MoodleService(
+    IHttpClientFactory httpClientFactory,
+    IDistributedCache cache,
+    ILogger<MoodleService> logger) : IMoodleService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static readonly TimeSpan CourseCacheDuration = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan ContentCacheDuration = TimeSpan.FromMinutes(2);
+
+    public async Task<IReadOnlyList<MoodleCourseDto>> GetEnrolledCoursesAsync(
+        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default)
+    {
+        string cacheKey = $"moodle:courses:{HashToken(moodleToken)}";
+
+        var cached = await GetFromCacheAsync<List<MoodleCourseDto>>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, "/core_enrol_get_users_courses", cancellationToken);
+
+        var courses = JsonSerializer.Deserialize<List<MoodleCourseDto>>(response, JsonOptions)
+            ?? [];
+
+        await SetCacheAsync(cacheKey, courses, CourseCacheDuration, cancellationToken);
+
+        return courses;
+    }
+
+    public async Task<IReadOnlyList<MoodleCourseSectionDto>> GetCourseContentAsync(
+        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default)
+    {
+        string cacheKey = $"moodle:content:{HashToken(moodleToken)}:{courseId}";
+
+        var cached = await GetFromCacheAsync<List<MoodleCourseSectionDto>>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, $"/core_course_get_contents?courseid={courseId}", cancellationToken);
+
+        var sections = JsonSerializer.Deserialize<List<MoodleCourseSectionDto>>(response, JsonOptions)
+            ?? [];
+
+        await SetCacheAsync(cacheKey, sections, ContentCacheDuration, cancellationToken);
+
+        return sections;
+    }
+
+    public async Task<MoodleSiteInfoDto> GetSiteInfoAsync(
+        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default)
+    {
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, "/core_webservice_get_site_info", cancellationToken);
+
+        return JsonSerializer.Deserialize<MoodleSiteInfoDto>(response, JsonOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize Moodle site info.");
+    }
+
+    private async Task<string> SendMoodleRequestAsync(
+        string moodleUrl, string moodleToken, string endpoint, CancellationToken cancellationToken)
+    {
+        using var client = httpClientFactory.CreateClient("Moodle");
+        client.BaseAddress = new Uri(moodleUrl.TrimEnd('/'));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", moodleToken);
+        client.Timeout = TimeSpan.FromSeconds(30);
+
+        logger.LogDebug("Calling MoodlewareAPI: {Endpoint}", endpoint);
+
+        using var response = await client.PostAsync(endpoint, null, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            logger.LogWarning("Moodle API returned 401 Unauthorized for endpoint {Endpoint}", endpoint);
+            throw new UnauthorizedAccessException("Moodle token is invalid or expired. Please re-link your Moodle account.");
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            string body = await response.Content.ReadAsStringAsync(cancellationToken);
+            logger.LogError("Moodle API error {StatusCode} for {Endpoint}: {Body}",
+                (int)response.StatusCode, endpoint, body);
+            throw new HttpRequestException(
+                $"Moodle API returned {(int)response.StatusCode}: {response.ReasonPhrase}");
+        }
+
+        return await response.Content.ReadAsStringAsync(cancellationToken);
+    }
+
+    private async Task<T?> GetFromCacheAsync<T>(string key, CancellationToken cancellationToken) where T : class
+    {
+        try
+        {
+            byte[]? data = await cache.GetAsync(key, cancellationToken);
+            if (data is null)
+                return null;
+
+            return JsonSerializer.Deserialize<T>(data, JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read from cache for key {Key}", key);
+            return null;
+        }
+    }
+
+    private async Task SetCacheAsync<T>(string key, T value, TimeSpan duration, CancellationToken cancellationToken)
+    {
+        try
+        {
+            byte[] data = JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions);
+            var options = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = duration,
+            };
+            await cache.SetAsync(key, data, options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to write to cache for key {Key}", key);
+        }
+    }
+
+    private static string HashToken(string token)
+    {
+        int hash = token.GetHashCode(StringComparison.Ordinal);
+        return hash.ToString("x8");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `IMoodleService` + `MoodleService` in Infrastructure layer that communicates with MoodlewareAPI
- Add Redis distributed caching (5min for courses, 2min for content) with graceful fallback
- CQRS: `GetEnrolledCoursesQuery` + `GetCourseContentQuery` with validators
- API endpoints: `GET /api/moodle/courses` and `GET /api/moodle/courses/{id}/content`
- Angular: `MoodleService`, `CoursesComponent` (grid with progress bars), `CourseDetailComponent` (sections + modules)
- Lazy-loaded course routes at `/courses` and `/courses/:courseId`
- Error handling for Moodle API failures (401 unauthorized, timeouts, generic errors)

## Test plan
- [x] `dotnet build` passes with 0 errors, 0 warnings
- [x] `bun run build` passes with 0 errors
- [ ] Manual test with linked Moodle account
- [ ] Verify Redis caching behavior

Closes #6