### PR TITLE
feat(pinned): pin/star system with CQRS, API endpoints, and frontend

### DIFF
--- a/src/Kursa.API/Controllers/PinnedContentsController.cs
+++ b/src/Kursa.API/Controllers/PinnedContentsController.cs
@@ -1,0 +1,55 @@
+using Kursa.Application.Features.PinnedContents.Commands;
+using Kursa.Application.Features.PinnedContents.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/pinned")]
+[Authorize]
+public class PinnedContentsController(ISender sender) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetPinnedContentsAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetPinnedContentsQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("{contentId:guid}")]
+    public async Task<IActionResult> PinContentAsync(Guid contentId, [FromBody] PinContentRequest? request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new PinContentCommand(contentId, request?.Notes), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(new { id = result.Value })
+            : BadRequest(result.Error);
+    }
+
+    [HttpDelete("{contentId:guid}")]
+    public async Task<IActionResult> UnpinContentAsync(Guid contentId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new UnpinContentCommand(contentId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok()
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("{contentId:guid}/star")]
+    public async Task<IActionResult> ToggleStarAsync(Guid contentId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new ToggleStarCommand(contentId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(new { isStarred = result.Value })
+            : BadRequest(result.Error);
+    }
+}
+
+public sealed record PinContentRequest(string? Notes);

--- a/src/Kursa.Application/Features/PinnedContents/Commands/PinContent.cs
+++ b/src/Kursa.Application/Features/PinnedContents/Commands/PinContent.cs
@@ -1,0 +1,60 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.PinnedContents.Commands;
+
+public sealed record PinContentCommand(Guid ContentId, string? Notes = null) : IRequest<Result<Guid>>;
+
+public sealed class PinContentValidator : AbstractValidator<PinContentCommand>
+{
+    public PinContentValidator()
+    {
+        RuleFor(x => x.ContentId).NotEmpty().WithMessage("Content ID is required.");
+        RuleFor(x => x.Notes).MaximumLength(2000).WithMessage("Notes cannot exceed 2000 characters.");
+    }
+}
+
+public sealed class PinContentHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<PinContentCommand, Result<Guid>>
+{
+    public async Task<Result<Guid>> Handle(PinContentCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<Guid>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<Guid>.Failure("User not found.");
+
+        var content = await dbContext.Contents
+            .FirstOrDefaultAsync(c => c.Id == request.ContentId, cancellationToken);
+
+        if (content is null)
+            return Result<Guid>.Failure("Content not found.");
+
+        var existing = await dbContext.PinnedContents
+            .FirstOrDefaultAsync(p => p.UserId == user.Id && p.ContentId == request.ContentId, cancellationToken);
+
+        if (existing is not null)
+            return Result<Guid>.Success(existing.Id);
+
+        var pinned = new PinnedContent
+        {
+            UserId = user.Id,
+            ContentId = request.ContentId,
+            Notes = request.Notes,
+        };
+
+        dbContext.PinnedContents.Add(pinned);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(pinned.Id);
+    }
+}

--- a/src/Kursa.Application/Features/PinnedContents/Commands/ToggleStar.cs
+++ b/src/Kursa.Application/Features/PinnedContents/Commands/ToggleStar.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.PinnedContents.Commands;
+
+public sealed record ToggleStarCommand(Guid ContentId) : IRequest<Result<bool>>;
+
+public sealed class ToggleStarValidator : AbstractValidator<ToggleStarCommand>
+{
+    public ToggleStarValidator()
+    {
+        RuleFor(x => x.ContentId).NotEmpty().WithMessage("Content ID is required.");
+    }
+}
+
+public sealed class ToggleStarHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<ToggleStarCommand, Result<bool>>
+{
+    public async Task<Result<bool>> Handle(ToggleStarCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<bool>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<bool>.Failure("User not found.");
+
+        var pinned = await dbContext.PinnedContents
+            .FirstOrDefaultAsync(p => p.UserId == user.Id && p.ContentId == request.ContentId, cancellationToken);
+
+        if (pinned is null)
+            return Result<bool>.Failure("Content is not pinned. Pin it first.");
+
+        pinned.IsStarred = !pinned.IsStarred;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<bool>.Success(pinned.IsStarred);
+    }
+}

--- a/src/Kursa.Application/Features/PinnedContents/Commands/UnpinContent.cs
+++ b/src/Kursa.Application/Features/PinnedContents/Commands/UnpinContent.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.PinnedContents.Commands;
+
+public sealed record UnpinContentCommand(Guid ContentId) : IRequest<Result>;
+
+public sealed class UnpinContentValidator : AbstractValidator<UnpinContentCommand>
+{
+    public UnpinContentValidator()
+    {
+        RuleFor(x => x.ContentId).NotEmpty().WithMessage("Content ID is required.");
+    }
+}
+
+public sealed class UnpinContentHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<UnpinContentCommand, Result>
+{
+    public async Task<Result> Handle(UnpinContentCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result.Failure("User not found.");
+
+        var pinned = await dbContext.PinnedContents
+            .FirstOrDefaultAsync(p => p.UserId == user.Id && p.ContentId == request.ContentId, cancellationToken);
+
+        if (pinned is null)
+            return Result.Success();
+
+        dbContext.PinnedContents.Remove(pinned);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Kursa.Application/Features/PinnedContents/PinnedContentDto.cs
+++ b/src/Kursa.Application/Features/PinnedContents/PinnedContentDto.cs
@@ -1,0 +1,13 @@
+namespace Kursa.Application.Features.PinnedContents;
+
+public sealed record PinnedContentDto(
+    Guid Id,
+    Guid ContentId,
+    string ContentTitle,
+    string? ContentDescription,
+    string ContentType,
+    string? Url,
+    bool IsStarred,
+    bool IsIndexed,
+    string? Notes,
+    DateTime PinnedAt);

--- a/src/Kursa.Application/Features/PinnedContents/Queries/GetPinnedContents.cs
+++ b/src/Kursa.Application/Features/PinnedContents/Queries/GetPinnedContents.cs
@@ -1,0 +1,47 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.PinnedContents.Queries;
+
+public sealed record GetPinnedContentsQuery : IRequest<Result<IReadOnlyList<PinnedContentDto>>>;
+
+public sealed class GetPinnedContentsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetPinnedContentsQuery, Result<IReadOnlyList<PinnedContentDto>>>
+{
+    public async Task<Result<IReadOnlyList<PinnedContentDto>>> Handle(
+        GetPinnedContentsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<PinnedContentDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<PinnedContentDto>>.Failure("User not found.");
+
+        var pinnedContents = await dbContext.PinnedContents
+            .AsNoTracking()
+            .Include(p => p.Content)
+            .Where(p => p.UserId == user.Id)
+            .OrderByDescending(p => p.CreatedAt)
+            .Select(p => new PinnedContentDto(
+                p.Id,
+                p.ContentId,
+                p.Content.Title,
+                p.Content.Description,
+                p.Content.Type.ToString(),
+                p.Content.Url,
+                p.IsStarred,
+                p.IsIndexed,
+                p.Notes,
+                p.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<PinnedContentDto>>.Success(pinnedContents);
+    }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -26,6 +26,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/courses/course-detail.component').then((m) => m.CourseDetailComponent),
       },
+      {
+        path: 'pinned',
+        loadComponent: () =>
+          import('./features/pinned/pinned.component').then((m) => m.PinnedComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/pinned-content.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/pinned-content.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface PinnedContent {
+  id: string;
+  contentId: string;
+  contentTitle: string;
+  contentDescription: string | null;
+  contentType: string;
+  url: string | null;
+  isStarred: boolean;
+  isIndexed: boolean;
+  notes: string | null;
+  pinnedAt: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PinnedContentService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/pinned';
+
+  getPinnedContents(): Observable<PinnedContent[]> {
+    return this.http.get<PinnedContent[]>(this.baseUrl);
+  }
+
+  pinContent(contentId: string, notes?: string): Observable<{ id: string }> {
+    return this.http.post<{ id: string }>(`${this.baseUrl}/${contentId}`, { notes });
+  }
+
+  unpinContent(contentId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${contentId}`);
+  }
+
+  toggleStar(contentId: string): Observable<{ isStarred: boolean }> {
+    return this.http.post<{ isStarred: boolean }>(`${this.baseUrl}/${contentId}/star`, {});
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/pinned/pinned.component.ts
+++ b/src/Kursa.Frontend/src/app/features/pinned/pinned.component.ts
@@ -1,0 +1,122 @@
+import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { PinnedContent, PinnedContentService } from '../../core/services/pinned-content.service';
+
+@Component({
+  selector: 'app-pinned',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe],
+  template: `
+    <div class="space-y-6">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-bold text-foreground">Pinned Items</h1>
+        <span class="text-sm text-muted-foreground">{{ items().length }} item{{ items().length === 1 ? '' : 's' }}</span>
+      </div>
+
+      @if (loading()) {
+        <div class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+          <span class="ml-3 text-muted-foreground">Loading pinned items...</span>
+        </div>
+      } @else if (error()) {
+        <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-6">
+          <p class="text-sm text-destructive">{{ error() }}</p>
+        </div>
+      } @else if (items().length === 0) {
+        <div class="rounded-lg border border-border bg-card p-8 text-center">
+          <svg class="mx-auto h-12 w-12 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+          </svg>
+          <h2 class="mt-4 text-lg font-semibold text-foreground">No pinned items</h2>
+          <p class="mt-2 text-sm text-muted-foreground">
+            Pin content from your courses to save it for quick access and AI features.
+          </p>
+        </div>
+      } @else {
+        <div class="space-y-3">
+          @for (item of items(); track item.id) {
+            <div class="flex items-center gap-4 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent">
+              <div class="flex h-10 w-10 items-center justify-center rounded bg-muted text-xs font-medium text-muted-foreground uppercase">
+                {{ item.contentType.slice(0, 3) }}
+              </div>
+
+              <div class="min-w-0 flex-1">
+                <p class="font-medium text-foreground">{{ item.contentTitle }}</p>
+                @if (item.notes) {
+                  <p class="text-xs text-muted-foreground truncate">{{ item.notes }}</p>
+                }
+                <p class="text-xs text-muted-foreground">
+                  Pinned {{ item.pinnedAt | date:'mediumDate' }}
+                </p>
+              </div>
+
+              <div class="flex items-center gap-2">
+                <button
+                  (click)="toggleStar(item)"
+                  [attr.aria-label]="item.isStarred ? 'Unstar' : 'Star'"
+                  class="rounded p-1.5 hover:bg-muted"
+                >
+                  <svg class="h-5 w-5" [class]="item.isStarred ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground'" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+                  </svg>
+                </button>
+                <button
+                  (click)="unpin(item)"
+                  aria-label="Unpin"
+                  class="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                >
+                  <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class PinnedComponent implements OnInit {
+  private readonly pinnedService = inject(PinnedContentService);
+
+  readonly items = signal<PinnedContent[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.loadPinned();
+  }
+
+  private loadPinned(): void {
+    this.loading.set(true);
+    this.pinnedService.getPinnedContents().subscribe({
+      next: (items) => {
+        this.items.set(items);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set(err.error ?? 'Failed to load pinned items.');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  toggleStar(item: PinnedContent): void {
+    this.pinnedService.toggleStar(item.contentId).subscribe({
+      next: (result) => {
+        this.items.update((items) =>
+          items.map((i) => (i.id === item.id ? { ...i, isStarred: result.isStarred } : i))
+        );
+      },
+    });
+  }
+
+  unpin(item: PinnedContent): void {
+    this.pinnedService.unpinContent(item.contentId).subscribe({
+      next: () => {
+        this.items.update((items) => items.filter((i) => i.id !== item.id));
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- CQRS: `PinContentCommand`, `UnpinContentCommand`, `ToggleStarCommand`, `GetPinnedContentsQuery` with validators
- API: `PinnedContentsController` with `GET/POST/DELETE /api/pinned/{contentId}` and `POST /api/pinned/{contentId}/star`
- Frontend: `PinnedContentService` + `PinnedComponent` with star toggle, unpin actions, empty state
- Lazy-loaded route at `/pinned`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `bun run build` — 0 errors
- [ ] Manual test: pin/unpin/star content items

Closes #8