### PR TITLE
feat(ai): integrate Qdrant + content embedding pipeline

### DIFF
--- a/src/Kursa.API/Controllers/PinnedContentsController.cs
+++ b/src/Kursa.API/Controllers/PinnedContentsController.cs
@@ -50,6 +50,16 @@ public class PinnedContentsController(ISender sender) : ControllerBase
             ? Ok(new { isStarred = result.Value })
             : BadRequest(result.Error);
     }
+
+    [HttpPost("{contentId:guid}/index")]
+    public async Task<IActionResult> IndexContentAsync(Guid contentId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new IndexPinnedContentCommand(contentId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok()
+            : BadRequest(result.Error);
+    }
 }
 
 public sealed record PinContentRequest(string? Notes);

--- a/src/Kursa.Application/Common/Interfaces/IContentPipeline.cs
+++ b/src/Kursa.Application/Common/Interfaces/IContentPipeline.cs
@@ -1,0 +1,8 @@
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IContentPipeline
+{
+    Task IndexContentAsync(Guid contentId, Guid userId, CancellationToken cancellationToken = default);
+
+    Task RemoveContentIndexAsync(Guid contentId, CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Common/Interfaces/IVectorStore.cs
+++ b/src/Kursa.Application/Common/Interfaces/IVectorStore.cs
@@ -1,0 +1,44 @@
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IVectorStore
+{
+    Task EnsureCollectionAsync(string collectionName, int vectorSize, CancellationToken cancellationToken = default);
+
+    Task UpsertAsync(string collectionName, IReadOnlyList<VectorPoint> points, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<VectorSearchResult>> SearchAsync(
+        string collectionName,
+        IReadOnlyList<float> queryVector,
+        int limit = 5,
+        Guid? filterByUserId = null,
+        Guid? filterByContentId = null,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteByContentIdAsync(string collectionName, Guid contentId, CancellationToken cancellationToken = default);
+}
+
+public sealed record VectorPoint
+{
+    public required Guid Id { get; init; }
+    public required IReadOnlyList<float> Vector { get; init; }
+    public required Guid ContentId { get; init; }
+    public required Guid UserId { get; init; }
+    public required string ChunkText { get; init; }
+    public required int ChunkIndex { get; init; }
+    public string? ContentTitle { get; init; }
+    public string? ContentType { get; init; }
+    public string? SourceUrl { get; init; }
+}
+
+public sealed record VectorSearchResult
+{
+    public required Guid Id { get; init; }
+    public required float Score { get; init; }
+    public required Guid ContentId { get; init; }
+    public required Guid UserId { get; init; }
+    public required string ChunkText { get; init; }
+    public required int ChunkIndex { get; init; }
+    public string? ContentTitle { get; init; }
+    public string? ContentType { get; init; }
+    public string? SourceUrl { get; init; }
+}

--- a/src/Kursa.Application/Features/PinnedContents/Commands/IndexPinnedContent.cs
+++ b/src/Kursa.Application/Features/PinnedContents/Commands/IndexPinnedContent.cs
@@ -1,0 +1,48 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Application.Features.PinnedContents.Commands;
+
+public sealed record IndexPinnedContentCommand(Guid ContentId) : IRequest<Result>;
+
+public sealed class IndexPinnedContentHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IContentPipeline contentPipeline,
+    ILogger<IndexPinnedContentHandler> logger) : IRequestHandler<IndexPinnedContentCommand, Result>
+{
+    public async Task<Result> Handle(IndexPinnedContentCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result.Failure("User not found.");
+
+        var pinnedContent = await dbContext.PinnedContents
+            .FirstOrDefaultAsync(p => p.ContentId == request.ContentId && p.UserId == user.Id, cancellationToken);
+
+        if (pinnedContent is null)
+            return Result.Failure("Content must be pinned before indexing.");
+
+        if (pinnedContent.IsIndexed)
+            return Result.Success();
+
+        try
+        {
+            await contentPipeline.IndexContentAsync(request.ContentId, user.Id, cancellationToken);
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to index content {ContentId}", request.ContentId);
+            return Result.Failure("Failed to index content. Please try again later.");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -61,6 +61,12 @@ public static class DependencyInjection
         services.AddOptions<OidcOptions>()
             .Bind(configuration.GetSection(OidcOptions.SectionName));
 
+        // Qdrant vector store
+        services.AddSingleton<IVectorStore, QdrantVectorStore>();
+
+        // Content embedding pipeline
+        services.AddScoped<IContentPipeline, ContentPipeline>();
+
         // LLM provider — configuration-driven selection
         services.AddSingleton<ILlmProvider>(sp =>
         {

--- a/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
+++ b/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="OpenAI" Version="2.2.0-beta.4" />
+    <PackageReference Include="Qdrant.Client" Version="1.17.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Kursa.Infrastructure/Services/ContentPipeline.cs
+++ b/src/Kursa.Infrastructure/Services/ContentPipeline.cs
@@ -1,0 +1,159 @@
+using System.Text.RegularExpressions;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed partial class ContentPipeline(
+    IAppDbContext dbContext,
+    ILlmProvider llmProvider,
+    IVectorStore vectorStore,
+    ILogger<ContentPipeline> logger) : IContentPipeline
+{
+    private const string CollectionName = "content_chunks";
+    private const int ChunkSize = 512;
+    private const int ChunkOverlap = 64;
+
+    public async Task IndexContentAsync(Guid contentId, Guid userId, CancellationToken cancellationToken = default)
+    {
+        Content? content = await dbContext.Contents
+            .Include(c => c.Module)
+            .FirstOrDefaultAsync(c => c.Id == contentId, cancellationToken);
+
+        if (content is null)
+        {
+            logger.LogWarning("Content {ContentId} not found for indexing", contentId);
+            return;
+        }
+
+        // Extract text from content
+        string text = ExtractText(content);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            logger.LogInformation("No text extracted from content {ContentId} ({Title}), skipping", contentId, content.Title);
+            return;
+        }
+
+        // Chunk the text
+        IReadOnlyList<string> chunks = ChunkText(text, ChunkSize, ChunkOverlap);
+        if (chunks.Count == 0) return;
+
+        logger.LogInformation("Indexing content {ContentId} ({Title}): {ChunkCount} chunks", contentId, content.Title, chunks.Count);
+
+        // Generate embedding for initial collection setup — get vector size from first embedding
+        IReadOnlyList<float> firstEmbedding = await llmProvider.GenerateEmbeddingAsync(chunks[0], cancellationToken);
+        await vectorStore.EnsureCollectionAsync(CollectionName, firstEmbedding.Count, cancellationToken);
+
+        // Generate embeddings for all chunks (batch)
+        IReadOnlyList<IReadOnlyList<float>> embeddings = await llmProvider.GenerateEmbeddingsAsync(
+            chunks.ToList(), cancellationToken);
+
+        // Build vector points
+        var points = new List<VectorPoint>(chunks.Count);
+        for (int i = 0; i < chunks.Count; i++)
+        {
+            points.Add(new VectorPoint
+            {
+                Id = Guid.NewGuid(),
+                Vector = embeddings[i],
+                ContentId = contentId,
+                UserId = userId,
+                ChunkText = chunks[i],
+                ChunkIndex = i,
+                ContentTitle = content.Title,
+                ContentType = content.Type.ToString(),
+                SourceUrl = content.Url,
+            });
+        }
+
+        // Delete existing vectors for this content (re-index scenario)
+        await vectorStore.DeleteByContentIdAsync(CollectionName, contentId, cancellationToken);
+
+        // Upsert new vectors
+        await vectorStore.UpsertAsync(CollectionName, points, cancellationToken);
+
+        // Mark content as indexed
+        PinnedContent? pinnedContent = await dbContext.PinnedContents
+            .FirstOrDefaultAsync(p => p.ContentId == contentId && p.UserId == userId, cancellationToken);
+
+        if (pinnedContent is not null)
+        {
+            pinnedContent.IsIndexed = true;
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        logger.LogInformation("Successfully indexed content {ContentId} ({Title}) with {ChunkCount} chunks", contentId, content.Title, chunks.Count);
+    }
+
+    public async Task RemoveContentIndexAsync(Guid contentId, CancellationToken cancellationToken = default)
+    {
+        await vectorStore.DeleteByContentIdAsync(CollectionName, contentId, cancellationToken);
+        logger.LogInformation("Removed index for content {ContentId}", contentId);
+    }
+
+    private static string ExtractText(Content content)
+    {
+        // For now, combine available text sources
+        // Future: add PDF extraction via a dedicated service, OCR, etc.
+        var parts = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(content.Title))
+            parts.Add(content.Title);
+
+        if (!string.IsNullOrWhiteSpace(content.Description))
+        {
+            string cleaned = StripHtml(content.Description);
+            parts.Add(cleaned);
+        }
+
+        return string.Join("\n\n", parts);
+    }
+
+    internal static string StripHtml(string html)
+    {
+        // Remove HTML tags
+        string text = HtmlTagRegex().Replace(html, " ");
+        // Decode common entities
+        text = text.Replace("&amp;", "&")
+                   .Replace("&lt;", "<")
+                   .Replace("&gt;", ">")
+                   .Replace("&quot;", "\"")
+                   .Replace("&nbsp;", " ");
+        // Collapse whitespace
+        text = WhitespaceRegex().Replace(text, " ").Trim();
+        return text;
+    }
+
+    internal static IReadOnlyList<string> ChunkText(string text, int chunkSize, int overlap)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return [];
+
+        // Split into words
+        string[] words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        if (words.Length <= chunkSize)
+            return [string.Join(' ', words)];
+
+        var chunks = new List<string>();
+        int step = chunkSize - overlap;
+
+        for (int i = 0; i < words.Length; i += step)
+        {
+            int end = Math.Min(i + chunkSize, words.Length);
+            string chunk = string.Join(' ', words[i..end]);
+            chunks.Add(chunk);
+
+            if (end >= words.Length) break;
+        }
+
+        return chunks;
+    }
+
+    [GeneratedRegex("<[^>]+>")]
+    private static partial Regex HtmlTagRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/src/Kursa.Infrastructure/Services/QdrantVectorStore.cs
+++ b/src/Kursa.Infrastructure/Services/QdrantVectorStore.cs
@@ -1,0 +1,127 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Infrastructure.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using static Qdrant.Client.Grpc.Conditions;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class QdrantVectorStore : IVectorStore
+{
+    private readonly QdrantClient _client;
+    private readonly ILogger<QdrantVectorStore> _logger;
+
+    public QdrantVectorStore(IOptions<QdrantOptions> options, ILogger<QdrantVectorStore> logger)
+    {
+        _logger = logger;
+        QdrantOptions qdrantOptions = options.Value;
+
+        _client = string.IsNullOrEmpty(qdrantOptions.ApiKey)
+            ? new QdrantClient(qdrantOptions.Host, qdrantOptions.Port)
+            : new QdrantClient(qdrantOptions.Host, qdrantOptions.Port, apiKey: qdrantOptions.ApiKey);
+    }
+
+    public async Task EnsureCollectionAsync(string collectionName, int vectorSize, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            bool exists = await _client.CollectionExistsAsync(collectionName, cancellationToken);
+            if (exists) return;
+
+            await _client.CreateCollectionAsync(
+                collectionName,
+                new VectorParams { Size = (ulong)vectorSize, Distance = Distance.Cosine },
+                cancellationToken: cancellationToken);
+
+            _logger.LogInformation("Created Qdrant collection '{Collection}' with vector size {Size}", collectionName, vectorSize);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to ensure Qdrant collection '{Collection}'", collectionName);
+            throw;
+        }
+    }
+
+    public async Task UpsertAsync(string collectionName, IReadOnlyList<VectorPoint> points, CancellationToken cancellationToken = default)
+    {
+        if (points.Count == 0) return;
+
+        var qdrantPoints = points.Select(p => new PointStruct
+        {
+            Id = p.Id,
+            Vectors = p.Vector.ToArray(),
+            Payload =
+            {
+                ["content_id"] = p.ContentId.ToString(),
+                ["user_id"] = p.UserId.ToString(),
+                ["chunk_text"] = p.ChunkText,
+                ["chunk_index"] = p.ChunkIndex,
+                ["content_title"] = p.ContentTitle ?? string.Empty,
+                ["content_type"] = p.ContentType ?? string.Empty,
+                ["source_url"] = p.SourceUrl ?? string.Empty,
+            }
+        }).ToList();
+
+        await _client.UpsertAsync(collectionName, qdrantPoints, cancellationToken: cancellationToken);
+        _logger.LogDebug("Upserted {Count} points to collection '{Collection}'", points.Count, collectionName);
+    }
+
+    public async Task<IReadOnlyList<VectorSearchResult>> SearchAsync(
+        string collectionName,
+        IReadOnlyList<float> queryVector,
+        int limit = 5,
+        Guid? filterByUserId = null,
+        Guid? filterByContentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        Filter? filter = null;
+
+        if (filterByUserId.HasValue && filterByContentId.HasValue)
+        {
+            filter = MatchKeyword("user_id", filterByUserId.Value.ToString())
+                   & MatchKeyword("content_id", filterByContentId.Value.ToString());
+        }
+        else if (filterByUserId.HasValue)
+        {
+            filter = MatchKeyword("user_id", filterByUserId.Value.ToString());
+        }
+        else if (filterByContentId.HasValue)
+        {
+            filter = MatchKeyword("content_id", filterByContentId.Value.ToString());
+        }
+
+        IReadOnlyList<ScoredPoint> results = await _client.SearchAsync(
+            collectionName,
+            queryVector.ToArray(),
+            filter: filter,
+            limit: (ulong)limit,
+            cancellationToken: cancellationToken);
+
+        return results.Select(r => new VectorSearchResult
+        {
+            Id = r.Id.Uuid != null ? Guid.Parse(r.Id.Uuid) : Guid.Empty,
+            Score = r.Score,
+            ContentId = Guid.TryParse(GetPayloadString(r, "content_id"), out Guid cid) ? cid : Guid.Empty,
+            UserId = Guid.TryParse(GetPayloadString(r, "user_id"), out Guid uid) ? uid : Guid.Empty,
+            ChunkText = GetPayloadString(r, "chunk_text"),
+            ChunkIndex = (int)(r.Payload.TryGetValue("chunk_index", out Value? ci) ? ci.IntegerValue : 0),
+            ContentTitle = GetPayloadString(r, "content_title"),
+            ContentType = GetPayloadString(r, "content_type"),
+            SourceUrl = GetPayloadString(r, "source_url"),
+        }).ToList();
+    }
+
+    public async Task DeleteByContentIdAsync(string collectionName, Guid contentId, CancellationToken cancellationToken = default)
+    {
+        Filter filter = MatchKeyword("content_id", contentId.ToString());
+        await _client.DeleteAsync(collectionName, filter, cancellationToken: cancellationToken);
+        _logger.LogInformation("Deleted vectors for content {ContentId} from collection '{Collection}'", contentId, collectionName);
+    }
+
+    private static string GetPayloadString(ScoredPoint point, string key)
+    {
+        return point.Payload.TryGetValue(key, out Value? value) ? value.StringValue : string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `IVectorStore` interface with upsert, search, and delete operations
- Implements `QdrantVectorStore` using Qdrant .NET SDK v1.17.0 with GUID-based point IDs
- Adds `IContentPipeline` interface for content indexing lifecycle
- Implements `ContentPipeline` with HTML stripping, word-level chunking (512 words, 64 overlap), and batch embedding via `ILlmProvider`
- Adds `IndexPinnedContent` CQRS command to trigger indexing on pinned content
- Adds `POST /api/pinned/{contentId}/index` endpoint
- Registers `QdrantVectorStore` (singleton) and `ContentPipeline` (scoped) in DI

Closes #9

## Test plan
- [x] Full solution builds with 0 warnings, 0 errors
- [x] Qdrant filter uses `MatchKeyword` for string payload matching
- [ ] Integration test with running Qdrant instance (manual)