### PR TITLE
feat(ai): add auto-summarization for pinned content

### DIFF
--- a/src/Kursa.API/Controllers/SummariesController.cs
+++ b/src/Kursa.API/Controllers/SummariesController.cs
@@ -1,0 +1,33 @@
+using Kursa.Application.Features.Summaries.Commands;
+using Kursa.Application.Features.Summaries.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/summaries")]
+[Authorize]
+public class SummariesController(ISender sender) : ControllerBase
+{
+    [HttpGet("{contentId:guid}")]
+    public async Task<IActionResult> GetSummaryAsync(Guid contentId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetContentSummaryQuery(contentId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : NotFound(result.Error);
+    }
+
+    [HttpPost("{contentId:guid}")]
+    public async Task<IActionResult> GenerateSummaryAsync(Guid contentId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GenerateSummaryCommand(contentId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(new { summary = result.Value })
+            : BadRequest(result.Error);
+    }
+}

--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -17,5 +17,7 @@ public interface IAppDbContext
 
     DbSet<UserSettings> UserSettings { get; }
 
+    DbSet<ContentSummary> ContentSummaries { get; }
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Common/Interfaces/ISummaryService.cs
+++ b/src/Kursa.Application/Common/Interfaces/ISummaryService.cs
@@ -1,0 +1,6 @@
+namespace Kursa.Application.Common.Interfaces;
+
+public interface ISummaryService
+{
+    Task<string> GenerateSummaryAsync(Guid contentId, Guid userId, CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Features/Summaries/Commands/GenerateSummary.cs
+++ b/src/Kursa.Application/Features/Summaries/Commands/GenerateSummary.cs
@@ -1,0 +1,49 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Application.Features.Summaries.Commands;
+
+public sealed record GenerateSummaryCommand(Guid ContentId) : IRequest<Result<string>>;
+
+public sealed class GenerateSummaryHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    ISummaryService summaryService,
+    ILogger<GenerateSummaryHandler> logger) : IRequestHandler<GenerateSummaryCommand, Result<string>>
+{
+    public async Task<Result<string>> Handle(GenerateSummaryCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<string>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<string>.Failure("User not found.");
+
+        var pinnedContent = await dbContext.PinnedContents
+            .FirstOrDefaultAsync(p => p.ContentId == request.ContentId && p.UserId == user.Id, cancellationToken);
+
+        if (pinnedContent is null)
+            return Result<string>.Failure("Content must be pinned before generating a summary.");
+
+        try
+        {
+            string summary = await summaryService.GenerateSummaryAsync(request.ContentId, user.Id, cancellationToken);
+
+            if (string.IsNullOrEmpty(summary))
+                return Result<string>.Failure("Could not generate summary — no content text available.");
+
+            return Result<string>.Success(summary);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to generate summary for content {ContentId}", request.ContentId);
+            return Result<string>.Failure("Failed to generate summary. Please try again later.");
+        }
+    }
+}

--- a/src/Kursa.Application/Features/Summaries/Queries/GetContentSummary.cs
+++ b/src/Kursa.Application/Features/Summaries/Queries/GetContentSummary.cs
@@ -1,0 +1,42 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Summaries.Queries;
+
+public sealed record ContentSummaryDto(Guid Id, Guid ContentId, string ContentTitle, string Summary, int TokensUsed, DateTime GeneratedAt);
+
+public sealed record GetContentSummaryQuery(Guid ContentId) : IRequest<Result<ContentSummaryDto>>;
+
+public sealed class GetContentSummaryHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetContentSummaryQuery, Result<ContentSummaryDto>>
+{
+    public async Task<Result<ContentSummaryDto>> Handle(GetContentSummaryQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<ContentSummaryDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<ContentSummaryDto>.Failure("User not found.");
+
+        var summary = await dbContext.ContentSummaries
+            .Include(s => s.Content)
+            .FirstOrDefaultAsync(s => s.ContentId == request.ContentId && s.UserId == user.Id, cancellationToken);
+
+        if (summary is null)
+            return Result<ContentSummaryDto>.Failure("No summary found for this content.");
+
+        return Result<ContentSummaryDto>.Success(new ContentSummaryDto(
+            summary.Id,
+            summary.ContentId,
+            summary.Content.Title,
+            summary.Summary,
+            summary.TokensUsed,
+            summary.CreatedAt));
+    }
+}

--- a/src/Kursa.Domain/Entities/ContentSummary.cs
+++ b/src/Kursa.Domain/Entities/ContentSummary.cs
@@ -1,0 +1,16 @@
+namespace Kursa.Domain.Entities;
+
+public class ContentSummary : BaseEntity
+{
+    public Guid ContentId { get; set; }
+
+    public Content Content { get; set; } = null!;
+
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public required string Summary { get; set; }
+
+    public int TokensUsed { get; set; }
+}

--- a/src/Kursa.Frontend/src/app/core/services/summary.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/summary.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface ContentSummaryDto {
+  id: string;
+  contentId: string;
+  contentTitle: string;
+  summary: string;
+  tokensUsed: number;
+  generatedAt: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SummaryService {
+  private readonly http = inject(HttpClient);
+
+  getSummary(contentId: string): Observable<ContentSummaryDto> {
+    return this.http.get<ContentSummaryDto>(`/api/summaries/${contentId}`);
+  }
+
+  generateSummary(contentId: string): Observable<{ summary: string }> {
+    return this.http.post<{ summary: string }>(`/api/summaries/${contentId}`, {});
+  }
+}

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -67,6 +67,9 @@ public static class DependencyInjection
         // Content embedding pipeline
         services.AddScoped<IContentPipeline, ContentPipeline>();
 
+        // Summary service
+        services.AddScoped<ISummaryService, SummaryService>();
+
         // LLM provider — configuration-driven selection
         services.AddSingleton<ILlmProvider>(sp =>
         {

--- a/src/Kursa.Infrastructure/Migrations/20260310213139_AddContentSummary.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310213139_AddContentSummary.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310213139_AddContentSummary")]
+    partial class AddContentSummary
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310213139_AddContentSummary.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310213139_AddContentSummary.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContentSummary : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ContentSummaries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Summary = table.Column<string>(type: "character varying(8192)", maxLength: 8192, nullable: false),
+                    TokensUsed = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ContentSummaries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ContentSummaries_Contents_ContentId",
+                        column: x => x.ContentId,
+                        principalTable: "Contents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ContentSummaries_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ContentSummaries_ContentId",
+                table: "ContentSummaries",
+                column: "ContentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ContentSummaries_UserId_ContentId",
+                table: "ContentSummaries",
+                columns: new[] { "UserId", "ContentId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ContentSummaries");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -18,6 +18,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<UserSettings> UserSettings => Set<UserSettings>();
 
+    public DbSet<ContentSummary> ContentSummaries => Set<ContentSummary>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);

--- a/src/Kursa.Infrastructure/Persistence/Configurations/ContentSummaryConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/ContentSummaryConfiguration.cs
@@ -1,0 +1,27 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class ContentSummaryConfiguration : IEntityTypeConfiguration<ContentSummary>
+{
+    public void Configure(EntityTypeBuilder<ContentSummary> builder)
+    {
+        builder.HasKey(cs => cs.Id);
+
+        builder.HasIndex(cs => new { cs.UserId, cs.ContentId }).IsUnique();
+
+        builder.Property(cs => cs.Summary).HasMaxLength(8192);
+
+        builder.HasOne(cs => cs.Content)
+            .WithMany()
+            .HasForeignKey(cs => cs.ContentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(cs => cs.User)
+            .WithMany()
+            .HasForeignKey(cs => cs.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Kursa.Infrastructure/Services/SummaryService.cs
+++ b/src/Kursa.Infrastructure/Services/SummaryService.cs
@@ -1,0 +1,90 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class SummaryService(
+    IAppDbContext dbContext,
+    ILlmProvider llmProvider,
+    ILogger<SummaryService> logger) : ISummaryService
+{
+    private const string SystemPrompt =
+        """
+        You are a study assistant. Generate a concise, well-structured summary of the provided content.
+        Focus on key concepts, important details, and main takeaways.
+        Use bullet points and clear headings where appropriate.
+        Keep the summary between 200 and 500 words.
+        Write in the same language as the source content.
+        """;
+
+    public async Task<string> GenerateSummaryAsync(Guid contentId, Guid userId, CancellationToken cancellationToken = default)
+    {
+        Content? content = await dbContext.Contents
+            .Include(c => c.Module)
+            .FirstOrDefaultAsync(c => c.Id == contentId, cancellationToken);
+
+        if (content is null)
+        {
+            logger.LogWarning("Content {ContentId} not found for summarization", contentId);
+            return string.Empty;
+        }
+
+        string text = BuildContentText(content);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            logger.LogInformation("No text available for summarization of content {ContentId}", contentId);
+            return string.Empty;
+        }
+
+        logger.LogInformation("Generating summary for content {ContentId} ({Title})", contentId, content.Title);
+
+        LlmChatResponse response = await llmProvider.ChatAsync(new LlmChatRequest
+        {
+            SystemPrompt = SystemPrompt,
+            Messages = [LlmMessage.User($"Please summarize the following content:\n\n{text}")],
+            Temperature = 0.3f,
+            MaxTokens = 1024,
+        }, cancellationToken);
+
+        // Upsert summary in database
+        ContentSummary? existing = await dbContext.ContentSummaries
+            .FirstOrDefaultAsync(s => s.ContentId == contentId && s.UserId == userId, cancellationToken);
+
+        if (existing is not null)
+        {
+            existing.Summary = response.Content;
+            existing.TokensUsed = response.TotalTokens;
+        }
+        else
+        {
+            dbContext.ContentSummaries.Add(new ContentSummary
+            {
+                ContentId = contentId,
+                UserId = userId,
+                Summary = response.Content,
+                TokensUsed = response.TotalTokens,
+            });
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Summary generated for content {ContentId}, {Tokens} tokens used", contentId, response.TotalTokens);
+
+        return response.Content;
+    }
+
+    private static string BuildContentText(Content content)
+    {
+        var parts = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(content.Title))
+            parts.Add($"Title: {content.Title}");
+
+        if (!string.IsNullOrWhiteSpace(content.Description))
+            parts.Add(content.Description);
+
+        return string.Join("\n\n", parts);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ContentSummary` entity with EF Core configuration and migration
- Implements `SummaryService` using `ILlmProvider` for AI-generated content summaries
- Adds `GenerateSummary` command and `GetContentSummary` query (CQRS)
- Adds `SummariesController` with GET/POST endpoints at `/api/summaries/{contentId}`
- Adds Angular `SummaryService` for frontend integration
- Summaries stored per-user per-content with upsert behavior (re-summarize updates existing)

Closes #12

## Test plan
- [x] Full solution builds with 0 warnings, 0 errors
- [x] Frontend builds successfully
- [x] EF migration generated cleanly
- [ ] Integration test with LLM provider (manual)