### PR TITLE
feat(ai): implement RAG chat with source citations

### DIFF
--- a/src/Kursa.API/Controllers/ChatController.cs
+++ b/src/Kursa.API/Controllers/ChatController.cs
@@ -1,0 +1,45 @@
+using Kursa.Application.Features.Chat.Commands;
+using Kursa.Application.Features.Chat.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/chat")]
+[Authorize]
+public class ChatController(ISender sender) : ControllerBase
+{
+    [HttpGet("threads")]
+    public async Task<IActionResult> GetThreadsAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetChatThreadsQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("threads/{threadId:guid}/messages")]
+    public async Task<IActionResult> GetMessagesAsync(Guid threadId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetChatMessagesQuery(threadId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : NotFound(result.Error);
+    }
+
+    [HttpPost("send")]
+    public async Task<IActionResult> SendMessageAsync([FromBody] SendChatRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new SendChatMessageCommand(request.ThreadId, request.Message), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+}
+
+public sealed record SendChatRequest(Guid? ThreadId, string Message);

--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -19,5 +19,9 @@ public interface IAppDbContext
 
     DbSet<ContentSummary> ContentSummaries { get; }
 
+    DbSet<ChatThread> ChatThreads { get; }
+
+    DbSet<ChatMessage> ChatMessages { get; }
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Chat/ChatDtos.cs
+++ b/src/Kursa.Application/Features/Chat/ChatDtos.cs
@@ -1,0 +1,9 @@
+namespace Kursa.Application.Features.Chat;
+
+public sealed record ChatThreadDto(Guid Id, string Title, DateTime CreatedAt, DateTime UpdatedAt);
+
+public sealed record ChatMessageDto(Guid Id, string Role, string Content, string? Citations, int TokensUsed, DateTime CreatedAt);
+
+public sealed record ChatResponseDto(ChatMessageDto Message, IReadOnlyList<CitationDto> Sources);
+
+public sealed record CitationDto(Guid ContentId, string ContentTitle, string ChunkText, float Score, string? SourceUrl);

--- a/src/Kursa.Application/Features/Chat/Commands/SendChatMessage.cs
+++ b/src/Kursa.Application/Features/Chat/Commands/SendChatMessage.cs
@@ -1,0 +1,177 @@
+using System.Text.Json;
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Application.Features.Chat.Commands;
+
+public sealed record SendChatMessageCommand(Guid? ThreadId, string Message) : IRequest<Result<ChatResponseDto>>;
+
+public sealed class SendChatMessageValidator : AbstractValidator<SendChatMessageCommand>
+{
+    public SendChatMessageValidator()
+    {
+        RuleFor(x => x.Message).NotEmpty().MaximumLength(4096);
+    }
+}
+
+public sealed class SendChatMessageHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    ILlmProvider llmProvider,
+    IVectorStore vectorStore,
+    ILogger<SendChatMessageHandler> logger) : IRequestHandler<SendChatMessageCommand, Result<ChatResponseDto>>
+{
+    private const string CollectionName = "content_chunks";
+
+    private const string SystemPrompt =
+        """
+        You are Kursa, an AI study assistant. Answer the user's question based on the provided context from their course materials.
+
+        Rules:
+        - Use ONLY the provided context to answer. If the context doesn't contain relevant information, say so.
+        - When referencing information from the context, cite the source using [Source N] format where N corresponds to the source number.
+        - Be concise but thorough. Use bullet points and structure where helpful.
+        - Write in the same language as the user's question.
+        - If the user asks something unrelated to study materials, politely redirect them.
+        """;
+
+    public async Task<Result<ChatResponseDto>> Handle(SendChatMessageCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<ChatResponseDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<ChatResponseDto>.Failure("User not found.");
+
+        // Get or create thread
+        ChatThread thread;
+        if (request.ThreadId.HasValue)
+        {
+            ChatThread? existing = await dbContext.ChatThreads
+                .Include(t => t.Messages.OrderBy(m => m.CreatedAt))
+                .FirstOrDefaultAsync(t => t.Id == request.ThreadId.Value && t.UserId == user.Id, cancellationToken);
+
+            if (existing is null)
+                return Result<ChatResponseDto>.Failure("Chat thread not found.");
+
+            thread = existing;
+        }
+        else
+        {
+            string title = request.Message.Length > 80
+                ? string.Concat(request.Message.AsSpan(0, 77), "...")
+                : request.Message;
+
+            thread = new ChatThread
+            {
+                UserId = user.Id,
+                Title = title,
+            };
+            dbContext.ChatThreads.Add(thread);
+        }
+
+        // Save user message
+        var userMessage = new ChatMessage
+        {
+            ThreadId = thread.Id,
+            Role = "user",
+            Content = request.Message,
+        };
+        dbContext.ChatMessages.Add(userMessage);
+
+        // RAG: embed the question and search for relevant chunks
+        IReadOnlyList<float> questionEmbedding = await llmProvider.GenerateEmbeddingAsync(request.Message, cancellationToken);
+
+        IReadOnlyList<VectorSearchResult> searchResults = await vectorStore.SearchAsync(
+            CollectionName,
+            questionEmbedding,
+            limit: 5,
+            filterByUserId: user.Id,
+            cancellationToken: cancellationToken);
+
+        // Build context with sources
+        var citations = new List<CitationDto>();
+        string contextBlock = string.Empty;
+
+        if (searchResults.Count > 0)
+        {
+            var contextParts = new List<string>();
+            for (int i = 0; i < searchResults.Count; i++)
+            {
+                VectorSearchResult result = searchResults[i];
+                contextParts.Add($"[Source {i + 1}] (from: {result.ContentTitle})\n{result.ChunkText}");
+                citations.Add(new CitationDto(
+                    result.ContentId,
+                    result.ContentTitle ?? "Unknown",
+                    result.ChunkText,
+                    result.Score,
+                    result.SourceUrl));
+            }
+            contextBlock = "## Relevant Context\n\n" + string.Join("\n\n---\n\n", contextParts);
+        }
+
+        // Build messages for LLM
+        var llmMessages = new List<LlmMessage>();
+
+        // Include recent conversation history (last 10 messages)
+        IEnumerable<ChatMessage> recentMessages = thread.Messages.TakeLast(10);
+        foreach (ChatMessage msg in recentMessages)
+        {
+            llmMessages.Add(new LlmMessage(msg.Role, msg.Content));
+        }
+
+        // Add current user message with context
+        string userPrompt = string.IsNullOrEmpty(contextBlock)
+            ? request.Message
+            : $"{contextBlock}\n\n## User Question\n{request.Message}";
+        llmMessages.Add(LlmMessage.User(userPrompt));
+
+        try
+        {
+            LlmChatResponse llmResponse = await llmProvider.ChatAsync(new LlmChatRequest
+            {
+                SystemPrompt = SystemPrompt,
+                Messages = llmMessages,
+                Temperature = 0.4f,
+                MaxTokens = 2048,
+            }, cancellationToken);
+
+            // Save assistant message
+            var assistantMessage = new ChatMessage
+            {
+                ThreadId = thread.Id,
+                Role = "assistant",
+                Content = llmResponse.Content,
+                Citations = citations.Count > 0 ? JsonSerializer.Serialize(citations) : null,
+                TokensUsed = llmResponse.TotalTokens,
+            };
+            dbContext.ChatMessages.Add(assistantMessage);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            var responseDto = new ChatResponseDto(
+                new ChatMessageDto(
+                    assistantMessage.Id,
+                    assistantMessage.Role,
+                    assistantMessage.Content,
+                    assistantMessage.Citations,
+                    assistantMessage.TokensUsed,
+                    assistantMessage.CreatedAt),
+                citations);
+
+            return Result<ChatResponseDto>.Success(responseDto);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get LLM response for thread {ThreadId}", thread.Id);
+            return Result<ChatResponseDto>.Failure("Failed to generate response. Please try again.");
+        }
+    }
+}

--- a/src/Kursa.Application/Features/Chat/Queries/GetChatMessages.cs
+++ b/src/Kursa.Application/Features/Chat/Queries/GetChatMessages.cs
@@ -1,0 +1,39 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Chat.Queries;
+
+public sealed record GetChatMessagesQuery(Guid ThreadId) : IRequest<Result<IReadOnlyList<ChatMessageDto>>>;
+
+public sealed class GetChatMessagesHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetChatMessagesQuery, Result<IReadOnlyList<ChatMessageDto>>>
+{
+    public async Task<Result<IReadOnlyList<ChatMessageDto>>> Handle(GetChatMessagesQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<ChatMessageDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<ChatMessageDto>>.Failure("User not found.");
+
+        var thread = await dbContext.ChatThreads
+            .FirstOrDefaultAsync(t => t.Id == request.ThreadId && t.UserId == user.Id, cancellationToken);
+
+        if (thread is null)
+            return Result<IReadOnlyList<ChatMessageDto>>.Failure("Thread not found.");
+
+        List<ChatMessageDto> messages = await dbContext.ChatMessages
+            .Where(m => m.ThreadId == request.ThreadId)
+            .OrderBy(m => m.CreatedAt)
+            .Select(m => new ChatMessageDto(m.Id, m.Role, m.Content, m.Citations, m.TokensUsed, m.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<ChatMessageDto>>.Success(messages);
+    }
+}

--- a/src/Kursa.Application/Features/Chat/Queries/GetChatThreads.cs
+++ b/src/Kursa.Application/Features/Chat/Queries/GetChatThreads.cs
@@ -1,0 +1,33 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Chat.Queries;
+
+public sealed record GetChatThreadsQuery : IRequest<Result<IReadOnlyList<ChatThreadDto>>>;
+
+public sealed class GetChatThreadsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetChatThreadsQuery, Result<IReadOnlyList<ChatThreadDto>>>
+{
+    public async Task<Result<IReadOnlyList<ChatThreadDto>>> Handle(GetChatThreadsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<ChatThreadDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<ChatThreadDto>>.Failure("User not found.");
+
+        List<ChatThreadDto> threads = await dbContext.ChatThreads
+            .Where(t => t.UserId == user.Id)
+            .OrderByDescending(t => t.UpdatedAt)
+            .Select(t => new ChatThreadDto(t.Id, t.Title, t.CreatedAt, t.UpdatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<ChatThreadDto>>.Success(threads);
+    }
+}

--- a/src/Kursa.Domain/Entities/ChatMessage.cs
+++ b/src/Kursa.Domain/Entities/ChatMessage.cs
@@ -1,0 +1,16 @@
+namespace Kursa.Domain.Entities;
+
+public class ChatMessage : BaseEntity
+{
+    public Guid ThreadId { get; set; }
+
+    public ChatThread Thread { get; set; } = null!;
+
+    public required string Role { get; set; }
+
+    public required string Content { get; set; }
+
+    public string? Citations { get; set; }
+
+    public int TokensUsed { get; set; }
+}

--- a/src/Kursa.Domain/Entities/ChatThread.cs
+++ b/src/Kursa.Domain/Entities/ChatThread.cs
@@ -1,0 +1,12 @@
+namespace Kursa.Domain.Entities;
+
+public class ChatThread : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public required string Title { get; set; }
+
+    public ICollection<ChatMessage> Messages { get; init; } = new List<ChatMessage>();
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -36,6 +36,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/pinned/pinned.component').then((m) => m.PinnedComponent),
       },
+      {
+        path: 'chat',
+        loadComponent: () =>
+          import('./features/chat/chat.component').then((m) => m.ChatComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/chat.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/chat.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface ChatThread {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  citations: string | null;
+  tokensUsed: number;
+  createdAt: string;
+}
+
+export interface Citation {
+  contentId: string;
+  contentTitle: string;
+  chunkText: string;
+  score: number;
+  sourceUrl: string | null;
+}
+
+export interface ChatResponse {
+  message: ChatMessage;
+  sources: Citation[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class ChatService {
+  private readonly http = inject(HttpClient);
+
+  getThreads(): Observable<ChatThread[]> {
+    return this.http.get<ChatThread[]>('/api/chat/threads');
+  }
+
+  getMessages(threadId: string): Observable<ChatMessage[]> {
+    return this.http.get<ChatMessage[]>(`/api/chat/threads/${threadId}/messages`);
+  }
+
+  sendMessage(message: string, threadId?: string): Observable<ChatResponse> {
+    return this.http.post<ChatResponse>('/api/chat/send', { threadId, message });
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/chat/chat.component.ts
+++ b/src/Kursa.Frontend/src/app/features/chat/chat.component.ts
@@ -1,0 +1,221 @@
+import { ChangeDetectionStrategy, Component, inject, signal, computed, ElementRef, viewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { ChatService, ChatThread, ChatMessage, Citation, ChatResponse } from '../../core/services/chat.service';
+
+@Component({
+  selector: 'app-chat',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, DatePipe],
+  template: `
+    <div class="flex h-full">
+      <!-- Thread sidebar -->
+      <aside class="w-64 shrink-0 border-r border-border bg-card p-4" role="complementary" aria-label="Chat threads">
+        <button
+          (click)="newThread()"
+          class="mb-4 w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          New Chat
+        </button>
+
+        <nav aria-label="Chat thread list">
+          <ul class="space-y-1" role="list">
+            @for (thread of threads(); track thread.id) {
+              <li>
+                <button
+                  (click)="selectThread(thread)"
+                  class="w-full rounded-md px-3 py-2 text-left text-sm transition-colors"
+                  [class]="thread.id === activeThreadId() ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-accent/50'"
+                >
+                  <span class="line-clamp-1">{{ thread.title }}</span>
+                </button>
+              </li>
+            }
+          </ul>
+        </nav>
+      </aside>
+
+      <!-- Chat area -->
+      <div class="flex flex-1 flex-col">
+        <!-- Messages -->
+        <div #messagesContainer class="flex-1 overflow-y-auto p-6 space-y-4" role="log" aria-label="Chat messages">
+          @if (messages().length === 0 && !loading()) {
+            <div class="flex h-full items-center justify-center">
+              <div class="text-center space-y-3">
+                <svg class="mx-auto h-12 w-12 text-muted-foreground/50" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                </svg>
+                <h3 class="text-lg font-medium text-foreground">Ask Kursa anything</h3>
+                <p class="text-sm text-muted-foreground">Questions are answered using your pinned course materials.</p>
+              </div>
+            </div>
+          }
+
+          @for (msg of messages(); track msg.id) {
+            <div [class]="msg.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
+              <div
+                class="max-w-2xl rounded-lg px-4 py-3"
+                [class]="msg.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'"
+              >
+                <p class="whitespace-pre-wrap text-sm">{{ msg.content }}</p>
+                <time class="mt-1 block text-xs opacity-60">{{ msg.createdAt | date:'short' }}</time>
+              </div>
+            </div>
+          }
+
+          @if (activeSources().length > 0) {
+            <div class="rounded-lg border border-border bg-card p-4">
+              <h4 class="mb-2 text-sm font-medium text-foreground">Sources</h4>
+              <ul class="space-y-2" role="list">
+                @for (source of activeSources(); track source.contentId; let i = $index) {
+                  <li class="text-xs text-muted-foreground">
+                    <span class="font-medium text-foreground">[{{ i + 1 }}]</span>
+                    {{ source.contentTitle }}
+                    <span class="italic"> — score: {{ source.score.toFixed(2) }}</span>
+                  </li>
+                }
+              </ul>
+            </div>
+          }
+
+          @if (loading()) {
+            <div class="flex justify-start">
+              <div class="rounded-lg bg-muted px-4 py-3">
+                <div class="flex space-x-1">
+                  <span class="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/50"></span>
+                  <span class="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/50" style="animation-delay: 0.15s"></span>
+                  <span class="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/50" style="animation-delay: 0.3s"></span>
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+
+        <!-- Input -->
+        <div class="border-t border-border p-4">
+          <form (submit)="send($event)" class="flex gap-3">
+            <label for="chat-input" class="sr-only">Type your message</label>
+            <input
+              id="chat-input"
+              type="text"
+              [(ngModel)]="inputMessage"
+              name="message"
+              placeholder="Ask about your course materials..."
+              [disabled]="loading()"
+              class="flex-1 rounded-md border border-input bg-background px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              [disabled]="loading() || !inputMessage.trim()"
+              class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              Send
+            </button>
+          </form>
+          @if (error()) {
+            <p class="mt-2 text-sm text-destructive" role="alert">{{ error() }}</p>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class ChatComponent {
+  private readonly chatService = inject(ChatService);
+  private readonly messagesContainer = viewChild<ElementRef<HTMLDivElement>>('messagesContainer');
+
+  readonly threads = signal<ChatThread[]>([]);
+  readonly messages = signal<ChatMessage[]>([]);
+  readonly activeThreadId = signal<string | null>(null);
+  readonly activeSources = signal<Citation[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+
+  inputMessage = '';
+
+  constructor() {
+    this.loadThreads();
+  }
+
+  loadThreads(): void {
+    this.chatService.getThreads().subscribe({
+      next: (threads) => this.threads.set(threads),
+      error: () => {},
+    });
+  }
+
+  selectThread(thread: ChatThread): void {
+    this.activeThreadId.set(thread.id);
+    this.activeSources.set([]);
+    this.chatService.getMessages(thread.id).subscribe({
+      next: (messages) => {
+        this.messages.set(messages);
+        this.scrollToBottom();
+      },
+      error: () => this.error.set('Failed to load messages.'),
+    });
+  }
+
+  newThread(): void {
+    this.activeThreadId.set(null);
+    this.messages.set([]);
+    this.activeSources.set([]);
+    this.error.set(null);
+  }
+
+  send(event: Event): void {
+    event.preventDefault();
+    const message = this.inputMessage.trim();
+    if (!message || this.loading()) return;
+
+    this.loading.set(true);
+    this.error.set(null);
+    this.inputMessage = '';
+
+    // Optimistically show user message
+    const tempUserMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: message,
+      citations: null,
+      tokensUsed: 0,
+      createdAt: new Date().toISOString(),
+    };
+    this.messages.update((msgs) => [...msgs, tempUserMsg]);
+    this.scrollToBottom();
+
+    const threadId = this.activeThreadId() ?? undefined;
+
+    this.chatService.sendMessage(message, threadId).subscribe({
+      next: (response: ChatResponse) => {
+        this.loading.set(false);
+
+        // Set thread ID if this was a new thread
+        if (!this.activeThreadId()) {
+          this.loadThreads();
+        }
+
+        this.messages.update((msgs) => [...msgs, response.message]);
+        this.activeSources.set(response.sources);
+
+        // Extract thread ID from response if available
+        if (response.message.id) {
+          this.scrollToBottom();
+        }
+      },
+      error: () => {
+        this.loading.set(false);
+        this.error.set('Failed to send message. Please try again.');
+      },
+    });
+  }
+
+  private scrollToBottom(): void {
+    setTimeout(() => {
+      const container = this.messagesContainer()?.nativeElement;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    });
+  }
+}

--- a/src/Kursa.Infrastructure/Migrations/20260310213541_AddChatEntities.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310213541_AddChatEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310213541_AddChatEntities")]
+    partial class AddChatEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310213541_AddChatEntities.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310213541_AddChatEntities.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChatEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChatThreads",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChatThreads", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ChatThreads_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChatMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ThreadId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Role = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Content = table.Column<string>(type: "character varying(16384)", maxLength: 16384, nullable: false),
+                    Citations = table.Column<string>(type: "character varying(8192)", maxLength: 8192, nullable: true),
+                    TokensUsed = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChatMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ChatMessages_ChatThreads_ThreadId",
+                        column: x => x.ThreadId,
+                        principalTable: "ChatThreads",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatMessages_ThreadId",
+                table: "ChatMessages",
+                column: "ThreadId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatThreads_UserId",
+                table: "ChatThreads",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChatMessages");
+
+            migrationBuilder.DropTable(
+                name: "ChatThreads");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -20,6 +20,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<ContentSummary> ContentSummaries => Set<ContentSummary>();
 
+    public DbSet<ChatThread> ChatThreads => Set<ChatThread>();
+
+    public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);

--- a/src/Kursa.Infrastructure/Persistence/Configurations/ChatMessageConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/ChatMessageConfiguration.cs
@@ -1,0 +1,24 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class ChatMessageConfiguration : IEntityTypeConfiguration<ChatMessage>
+{
+    public void Configure(EntityTypeBuilder<ChatMessage> builder)
+    {
+        builder.HasKey(m => m.Id);
+
+        builder.Property(m => m.Role).HasMaxLength(32);
+        builder.Property(m => m.Content).HasMaxLength(16384);
+        builder.Property(m => m.Citations).HasMaxLength(8192);
+
+        builder.HasIndex(m => m.ThreadId);
+
+        builder.HasOne(m => m.Thread)
+            .WithMany(t => t.Messages)
+            .HasForeignKey(m => m.ThreadId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/Configurations/ChatThreadConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/ChatThreadConfiguration.cs
@@ -1,0 +1,22 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class ChatThreadConfiguration : IEntityTypeConfiguration<ChatThread>
+{
+    public void Configure(EntityTypeBuilder<ChatThread> builder)
+    {
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Title).HasMaxLength(256);
+
+        builder.HasIndex(t => t.UserId);
+
+        builder.HasOne(t => t.User)
+            .WithMany()
+            .HasForeignKey(t => t.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ChatThread` and `ChatMessage` domain entities with EF Core configurations and migration
- Implements `SendChatMessage` command with full RAG pipeline: embed question → search Qdrant → assemble context → LLM response with `[Source N]` citations
- Adds `GetChatThreads` and `GetChatMessages` queries
- Adds `ChatController` with endpoints: GET threads, GET messages, POST send
- Creates Angular chat component with thread sidebar, message bubbles, typing indicator, and source citations panel
- Adds `/chat` route to app routes

Closes #10

## Test plan
- [x] .NET solution builds with 0 warnings, 0 errors
- [x] Angular frontend builds successfully
- [x] EF migration generated cleanly
- [x] Chat route added and sidebar link already exists
- [ ] Integration test with Qdrant + LLM provider (manual)