### PR TITLE
fix(frontend): display readable error messages instead of [object Object]

### DIFF
--- a/src/Kursa.Frontend/src/app/features/courses/courses.component.ts
+++ b/src/Kursa.Frontend/src/app/features/courses/courses.component.ts
@@ -90,7 +90,8 @@ export class CoursesComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        this.error.set(err.error ?? 'Failed to load courses. Please check your Moodle connection.');
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to load courses. Please check your Moodle connection.';
+        this.error.set(message);
         this.loading.set(false);
       },
     });

--- a/src/Kursa.Frontend/src/app/features/pinned/pinned.component.ts
+++ b/src/Kursa.Frontend/src/app/features/pinned/pinned.component.ts
@@ -96,7 +96,8 @@ export class PinnedComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        this.error.set(err.error ?? 'Failed to load pinned items.');
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to load pinned items.';
+        this.error.set(message);
         this.loading.set(false);
       },
     });


### PR DESCRIPTION
## Summary
- Fixes courses and pinned pages showing `[object Object]` when backend is unavailable
- Extracts error message string from HTTP error response, falls back to `err.message`

Closes #55

## Test plan
- [x] Frontend builds with 0 errors
- [x] Verified with Playwright: courses page now shows readable error string