### PR TITLE
feat(quiz): add AI quiz generator with full CRUD and taking UI

### DIFF
--- a/src/Kursa.API/Controllers/QuizzesController.cs
+++ b/src/Kursa.API/Controllers/QuizzesController.cs
@@ -1,0 +1,93 @@
+using Kursa.Application.Features.Quizzes.Commands;
+using Kursa.Application.Features.Quizzes.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/quizzes")]
+[Authorize]
+public class QuizzesController(ISender sender) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetQuizzesAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetQuizzesQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("{quizId:guid}")]
+    public async Task<IActionResult> GetQuizDetailAsync(Guid quizId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetQuizDetailQuery(quizId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : NotFound(result.Error);
+    }
+
+    [HttpPost("generate")]
+    public async Task<IActionResult> GenerateQuizAsync([FromBody] GenerateQuizRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GenerateQuizCommand(
+            request.ContentId,
+            request.QuestionCount,
+            request.Topic,
+            request.DurationSeconds), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("{quizId:guid}/submit")]
+    public async Task<IActionResult> SubmitAttemptAsync(Guid quizId, [FromBody] SubmitAttemptRequest request, CancellationToken cancellationToken)
+    {
+        var answers = request.Answers
+            .Select(a => new AnswerSubmission(a.QuestionId, a.Answer))
+            .ToList();
+
+        var result = await sender.Send(new SubmitQuizAttemptCommand(quizId, answers, request.DurationSeconds), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("{quizId:guid}/results")]
+    public async Task<IActionResult> GetQuizResultsAsync(Guid quizId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetQuizResultsQuery(quizId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : NotFound(result.Error);
+    }
+
+    [HttpGet("attempts/{attemptId:guid}")]
+    public async Task<IActionResult> GetAttemptDetailAsync(Guid attemptId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetAttemptDetailQuery(attemptId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : NotFound(result.Error);
+    }
+}
+
+public sealed record GenerateQuizRequest(
+    Guid ContentId,
+    int QuestionCount = 10,
+    string? Topic = null,
+    int DurationSeconds = 600);
+
+public sealed record SubmitAttemptRequest(
+    IReadOnlyList<AnswerSubmissionRequest> Answers,
+    int DurationSeconds);
+
+public sealed record AnswerSubmissionRequest(Guid QuestionId, string Answer);

--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -23,5 +23,13 @@ public interface IAppDbContext
 
     DbSet<ChatMessage> ChatMessages { get; }
 
+    DbSet<Quiz> Quizzes { get; }
+
+    DbSet<QuizQuestion> QuizQuestions { get; }
+
+    DbSet<QuizAttempt> QuizAttempts { get; }
+
+    DbSet<QuizAnswer> QuizAnswers { get; }
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Quizzes/Commands/GenerateQuiz.cs
+++ b/src/Kursa.Application/Features/Quizzes/Commands/GenerateQuiz.cs
@@ -1,0 +1,245 @@
+using System.Text.Json;
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Application.Features.Quizzes.Commands;
+
+public sealed record GenerateQuizCommand(
+    Guid ContentId,
+    int QuestionCount = 10,
+    string? Topic = null,
+    int DurationSeconds = 600) : IRequest<Result<QuizDetailDto>>;
+
+public sealed class GenerateQuizValidator : AbstractValidator<GenerateQuizCommand>
+{
+    public GenerateQuizValidator()
+    {
+        RuleFor(x => x.ContentId).NotEmpty();
+        RuleFor(x => x.QuestionCount).InclusiveBetween(1, 50);
+        RuleFor(x => x.DurationSeconds).InclusiveBetween(60, 7200);
+    }
+}
+
+public sealed class GenerateQuizHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    ILlmProvider llmProvider,
+    IVectorStore vectorStore,
+    ILogger<GenerateQuizHandler> logger) : IRequestHandler<GenerateQuizCommand, Result<QuizDetailDto>>
+{
+    private const string CollectionName = "content_chunks";
+
+    private const string SystemPrompt =
+        """
+        You are a quiz generator for educational materials. Generate questions based on the provided content.
+
+        Rules:
+        - Generate exactly the requested number of questions.
+        - Mix question types: multiple_choice, true_false, fill_in_the_blank.
+        - For multiple_choice: provide exactly 4 options, one must be the correct answer.
+        - For true_false: the correct answer must be exactly "True" or "False".
+        - For fill_in_the_blank: the question should contain "___" where the answer goes.
+        - Each question must have an explanation for the correct answer.
+        - Questions should test understanding, not just memorization.
+        - Write questions in the same language as the source material.
+
+        Respond ONLY with valid JSON in this exact format:
+        {
+          "questions": [
+            {
+              "question": "What is...?",
+              "type": "multiple_choice",
+              "options": ["A", "B", "C", "D"],
+              "correct_answer": "A",
+              "explanation": "Because..."
+            }
+          ]
+        }
+        """;
+
+    public async Task<Result<QuizDetailDto>> Handle(GenerateQuizCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<QuizDetailDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<QuizDetailDto>.Failure("User not found.");
+
+        // Verify content is pinned and indexed
+        var pinnedContent = await dbContext.PinnedContents
+            .Include(p => p.Content)
+            .FirstOrDefaultAsync(p => p.ContentId == request.ContentId && p.UserId == user.Id, cancellationToken);
+
+        if (pinnedContent is null)
+            return Result<QuizDetailDto>.Failure("Content must be pinned before generating a quiz.");
+
+        if (!pinnedContent.IsIndexed)
+            return Result<QuizDetailDto>.Failure("Content must be indexed before generating a quiz. Please wait for indexing to complete.");
+
+        // Retrieve content chunks from vector store
+        string searchQuery = request.Topic ?? pinnedContent.Content.Title;
+        IReadOnlyList<float> queryEmbedding = await llmProvider.GenerateEmbeddingAsync(searchQuery, cancellationToken);
+
+        IReadOnlyList<VectorSearchResult> searchResults = await vectorStore.SearchAsync(
+            CollectionName,
+            queryEmbedding,
+            limit: 10,
+            filterByUserId: user.Id,
+            filterByContentId: request.ContentId,
+            cancellationToken: cancellationToken);
+
+        if (searchResults.Count == 0)
+            return Result<QuizDetailDto>.Failure("No indexed content found to generate questions from.");
+
+        // Build context from chunks
+        string context = string.Join("\n\n---\n\n",
+            searchResults.Select(r => r.ChunkText));
+
+        string userPrompt = $"""
+            Generate {request.QuestionCount} questions from the following material:
+
+            {context}
+
+            {(request.Topic is not null ? $"Focus on the topic: {request.Topic}" : "Cover the main concepts.")}
+            """;
+
+        try
+        {
+            LlmChatResponse llmResponse = await llmProvider.ChatAsync(new LlmChatRequest
+            {
+                SystemPrompt = SystemPrompt,
+                Messages = [LlmMessage.User(userPrompt)],
+                Temperature = 0.5f,
+                MaxTokens = 4096,
+            }, cancellationToken);
+
+            // Parse the LLM response
+            var generated = ParseQuizResponse(llmResponse.Content);
+
+            if (generated.Count == 0)
+                return Result<QuizDetailDto>.Failure("Failed to generate quiz questions. Please try again.");
+
+            // Create quiz entity
+            var quiz = new Quiz
+            {
+                UserId = user.Id,
+                Title = request.Topic is not null
+                    ? $"Quiz: {request.Topic}"
+                    : $"Quiz: {pinnedContent.Content.Title}",
+                Topic = request.Topic,
+                ContentId = request.ContentId,
+                QuestionCount = generated.Count,
+                DurationSeconds = request.DurationSeconds,
+            };
+
+            for (int i = 0; i < generated.Count; i++)
+            {
+                var q = generated[i];
+                quiz.Questions.Add(new QuizQuestion
+                {
+                    QuizId = quiz.Id,
+                    QuestionText = q.Question,
+                    Type = q.Type,
+                    Options = q.Options is not null ? JsonSerializer.Serialize(q.Options) : null,
+                    CorrectAnswer = q.CorrectAnswer,
+                    Explanation = q.Explanation,
+                    OrderIndex = i,
+                });
+            }
+
+            dbContext.Quizzes.Add(quiz);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            // Build response DTO
+            var questionDtos = quiz.Questions
+                .OrderBy(q => q.OrderIndex)
+                .Select(q => new QuizQuestionDto(
+                    q.Id,
+                    q.QuestionText,
+                    q.Type,
+                    q.Options is not null ? JsonSerializer.Deserialize<List<string>>(q.Options) : null,
+                    q.OrderIndex))
+                .ToList();
+
+            return Result<QuizDetailDto>.Success(new QuizDetailDto(
+                quiz.Id,
+                quiz.Title,
+                quiz.Topic,
+                quiz.DurationSeconds,
+                questionDtos));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to generate quiz for content {ContentId}", request.ContentId);
+            return Result<QuizDetailDto>.Failure("Failed to generate quiz. Please try again.");
+        }
+    }
+
+    private static List<GeneratedQuestion> ParseQuizResponse(string llmContent)
+    {
+        var result = new List<GeneratedQuestion>();
+
+        try
+        {
+            // Extract JSON from response (may be wrapped in markdown code block)
+            string json = llmContent;
+            int jsonStart = json.IndexOf('{');
+            int jsonEnd = json.LastIndexOf('}');
+            if (jsonStart >= 0 && jsonEnd > jsonStart)
+            {
+                json = json[jsonStart..(jsonEnd + 1)];
+            }
+
+            using var doc = JsonDocument.Parse(json);
+            JsonElement questions = doc.RootElement.GetProperty("questions");
+
+            foreach (JsonElement q in questions.EnumerateArray())
+            {
+                string typeStr = q.GetProperty("type").GetString() ?? "multiple_choice";
+                QuestionType type = typeStr switch
+                {
+                    "true_false" => QuestionType.TrueFalse,
+                    "fill_in_the_blank" => QuestionType.FillInTheBlank,
+                    "open_ended" => QuestionType.OpenEnded,
+                    _ => QuestionType.MultipleChoice,
+                };
+
+                List<string>? options = null;
+                if (q.TryGetProperty("options", out JsonElement optionsEl) && optionsEl.ValueKind == JsonValueKind.Array)
+                {
+                    options = optionsEl.EnumerateArray()
+                        .Select(o => o.GetString() ?? string.Empty)
+                        .ToList();
+                }
+
+                result.Add(new GeneratedQuestion(
+                    q.GetProperty("question").GetString() ?? string.Empty,
+                    type,
+                    options,
+                    q.GetProperty("correct_answer").GetString() ?? string.Empty,
+                    q.TryGetProperty("explanation", out JsonElement explEl) ? explEl.GetString() : null));
+            }
+        }
+        catch (JsonException)
+        {
+            // Return empty if parsing fails
+        }
+
+        return result;
+    }
+
+    private sealed record GeneratedQuestion(
+        string Question,
+        QuestionType Type,
+        List<string>? Options,
+        string CorrectAnswer,
+        string? Explanation);
+}

--- a/src/Kursa.Application/Features/Quizzes/Commands/SubmitQuizAttempt.cs
+++ b/src/Kursa.Application/Features/Quizzes/Commands/SubmitQuizAttempt.cs
@@ -1,0 +1,114 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Quizzes.Commands;
+
+public sealed record SubmitQuizAttemptCommand(
+    Guid QuizId,
+    IReadOnlyList<AnswerSubmission> Answers,
+    int DurationSeconds) : IRequest<Result<QuizAttemptDetailDto>>;
+
+public sealed record AnswerSubmission(Guid QuestionId, string Answer);
+
+public sealed class SubmitQuizAttemptValidator : AbstractValidator<SubmitQuizAttemptCommand>
+{
+    public SubmitQuizAttemptValidator()
+    {
+        RuleFor(x => x.QuizId).NotEmpty();
+        RuleFor(x => x.Answers).NotEmpty();
+        RuleFor(x => x.DurationSeconds).GreaterThanOrEqualTo(0);
+    }
+}
+
+public sealed class SubmitQuizAttemptHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<SubmitQuizAttemptCommand, Result<QuizAttemptDetailDto>>
+{
+    public async Task<Result<QuizAttemptDetailDto>> Handle(SubmitQuizAttemptCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<QuizAttemptDetailDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<QuizAttemptDetailDto>.Failure("User not found.");
+
+        var quiz = await dbContext.Quizzes
+            .Include(q => q.Questions)
+            .FirstOrDefaultAsync(q => q.Id == request.QuizId && q.UserId == user.Id, cancellationToken);
+
+        if (quiz is null)
+            return Result<QuizAttemptDetailDto>.Failure("Quiz not found.");
+
+        // Grade answers
+        var questionMap = quiz.Questions.ToDictionary(q => q.Id);
+        int score = 0;
+        var answers = new List<QuizAnswer>();
+        var answerDtos = new List<QuizAnswerDto>();
+
+        foreach (AnswerSubmission submission in request.Answers)
+        {
+            if (!questionMap.TryGetValue(submission.QuestionId, out QuizQuestion? question))
+                continue;
+
+            bool isCorrect = string.Equals(
+                submission.Answer.Trim(),
+                question.CorrectAnswer.Trim(),
+                StringComparison.OrdinalIgnoreCase);
+
+            if (isCorrect) score++;
+
+            var answer = new QuizAnswer
+            {
+                QuestionId = submission.QuestionId,
+                UserAnswer = submission.Answer,
+                IsCorrect = isCorrect,
+            };
+            answers.Add(answer);
+
+            answerDtos.Add(new QuizAnswerDto(
+                question.Id,
+                question.QuestionText,
+                question.Type,
+                submission.Answer,
+                question.CorrectAnswer,
+                question.Explanation,
+                isCorrect));
+        }
+
+        var attempt = new QuizAttempt
+        {
+            QuizId = quiz.Id,
+            UserId = user.Id,
+            Score = score,
+            TotalQuestions = quiz.QuestionCount,
+            DurationSeconds = request.DurationSeconds,
+            CompletedAt = DateTime.UtcNow,
+        };
+
+        dbContext.QuizAttempts.Add(attempt);
+
+        foreach (var answer in answers)
+        {
+            answer.AttemptId = attempt.Id;
+            dbContext.QuizAnswers.Add(answer);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<QuizAttemptDetailDto>.Success(new QuizAttemptDetailDto(
+            attempt.Id,
+            attempt.QuizId,
+            attempt.Score,
+            attempt.TotalQuestions,
+            attempt.DurationSeconds,
+            attempt.CompletedAt ?? DateTime.UtcNow,
+            answerDtos));
+    }
+}

--- a/src/Kursa.Application/Features/Quizzes/Queries/GetAttemptDetail.cs
+++ b/src/Kursa.Application/Features/Quizzes/Queries/GetAttemptDetail.cs
@@ -1,0 +1,54 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Quizzes.Queries;
+
+public sealed record GetAttemptDetailQuery(Guid AttemptId) : IRequest<Result<QuizAttemptDetailDto>>;
+
+public sealed class GetAttemptDetailHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetAttemptDetailQuery, Result<QuizAttemptDetailDto>>
+{
+    public async Task<Result<QuizAttemptDetailDto>> Handle(GetAttemptDetailQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<QuizAttemptDetailDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<QuizAttemptDetailDto>.Failure("User not found.");
+
+        var attempt = await dbContext.QuizAttempts
+            .Include(a => a.Answers)
+                .ThenInclude(a => a.Question)
+            .FirstOrDefaultAsync(a => a.Id == request.AttemptId && a.UserId == user.Id, cancellationToken);
+
+        if (attempt is null)
+            return Result<QuizAttemptDetailDto>.Failure("Attempt not found.");
+
+        var answerDtos = attempt.Answers
+            .Select(a => new QuizAnswerDto(
+                a.QuestionId,
+                a.Question.QuestionText,
+                a.Question.Type,
+                a.UserAnswer,
+                a.Question.CorrectAnswer,
+                a.Question.Explanation,
+                a.IsCorrect))
+            .ToList();
+
+        return Result<QuizAttemptDetailDto>.Success(new QuizAttemptDetailDto(
+            attempt.Id,
+            attempt.QuizId,
+            attempt.Score,
+            attempt.TotalQuestions,
+            attempt.DurationSeconds,
+            attempt.CompletedAt ?? attempt.CreatedAt,
+            answerDtos));
+    }
+}

--- a/src/Kursa.Application/Features/Quizzes/Queries/GetQuizDetail.cs
+++ b/src/Kursa.Application/Features/Quizzes/Queries/GetQuizDetail.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Quizzes.Queries;
+
+public sealed record GetQuizDetailQuery(Guid QuizId) : IRequest<Result<QuizDetailDto>>;
+
+public sealed class GetQuizDetailHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetQuizDetailQuery, Result<QuizDetailDto>>
+{
+    public async Task<Result<QuizDetailDto>> Handle(GetQuizDetailQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<QuizDetailDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<QuizDetailDto>.Failure("User not found.");
+
+        var quiz = await dbContext.Quizzes
+            .Include(q => q.Questions.OrderBy(qq => qq.OrderIndex))
+            .FirstOrDefaultAsync(q => q.Id == request.QuizId && q.UserId == user.Id, cancellationToken);
+
+        if (quiz is null)
+            return Result<QuizDetailDto>.Failure("Quiz not found.");
+
+        var questions = quiz.Questions.Select(q => new QuizQuestionDto(
+            q.Id,
+            q.QuestionText,
+            q.Type,
+            q.Options is not null ? JsonSerializer.Deserialize<List<string>>(q.Options) : null,
+            q.OrderIndex)).ToList();
+
+        return Result<QuizDetailDto>.Success(new QuizDetailDto(
+            quiz.Id,
+            quiz.Title,
+            quiz.Topic,
+            quiz.DurationSeconds,
+            questions));
+    }
+}

--- a/src/Kursa.Application/Features/Quizzes/Queries/GetQuizResults.cs
+++ b/src/Kursa.Application/Features/Quizzes/Queries/GetQuizResults.cs
@@ -1,0 +1,47 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Quizzes.Queries;
+
+public sealed record GetQuizResultsQuery(Guid QuizId) : IRequest<Result<IReadOnlyList<QuizAttemptDto>>>;
+
+public sealed class GetQuizResultsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetQuizResultsQuery, Result<IReadOnlyList<QuizAttemptDto>>>
+{
+    public async Task<Result<IReadOnlyList<QuizAttemptDto>>> Handle(GetQuizResultsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<QuizAttemptDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<QuizAttemptDto>>.Failure("User not found.");
+
+        // Verify quiz belongs to user
+        bool quizExists = await dbContext.Quizzes
+            .AnyAsync(q => q.Id == request.QuizId && q.UserId == user.Id, cancellationToken);
+
+        if (!quizExists)
+            return Result<IReadOnlyList<QuizAttemptDto>>.Failure("Quiz not found.");
+
+        List<QuizAttemptDto> attempts = await dbContext.QuizAttempts
+            .Where(a => a.QuizId == request.QuizId && a.UserId == user.Id)
+            .OrderByDescending(a => a.CompletedAt)
+            .Select(a => new QuizAttemptDto(
+                a.Id,
+                a.QuizId,
+                a.Score,
+                a.TotalQuestions,
+                a.DurationSeconds,
+                a.CompletedAt ?? a.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<QuizAttemptDto>>.Success(attempts);
+    }
+}

--- a/src/Kursa.Application/Features/Quizzes/Queries/GetQuizzes.cs
+++ b/src/Kursa.Application/Features/Quizzes/Queries/GetQuizzes.cs
@@ -1,0 +1,41 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Quizzes.Queries;
+
+public sealed record GetQuizzesQuery : IRequest<Result<IReadOnlyList<QuizDto>>>;
+
+public sealed class GetQuizzesHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetQuizzesQuery, Result<IReadOnlyList<QuizDto>>>
+{
+    public async Task<Result<IReadOnlyList<QuizDto>>> Handle(GetQuizzesQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<QuizDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<QuizDto>>.Failure("User not found.");
+
+        List<QuizDto> quizzes = await dbContext.Quizzes
+            .Where(q => q.UserId == user.Id)
+            .OrderByDescending(q => q.CreatedAt)
+            .Select(q => new QuizDto(
+                q.Id,
+                q.Title,
+                q.Topic,
+                q.QuestionCount,
+                q.DurationSeconds,
+                q.Attempts.Count,
+                q.Attempts.Any() ? q.Attempts.Max(a => a.Score) : null,
+                q.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<QuizDto>>.Success(quizzes);
+    }
+}

--- a/src/Kursa.Application/Features/Quizzes/QuizDtos.cs
+++ b/src/Kursa.Application/Features/Quizzes/QuizDtos.cs
@@ -1,0 +1,62 @@
+using Kursa.Domain.Entities;
+
+namespace Kursa.Application.Features.Quizzes;
+
+public sealed record QuizDto(
+    Guid Id,
+    string Title,
+    string? Topic,
+    int QuestionCount,
+    int DurationSeconds,
+    int AttemptCount,
+    int? BestScore,
+    DateTime CreatedAt);
+
+public sealed record QuizDetailDto(
+    Guid Id,
+    string Title,
+    string? Topic,
+    int DurationSeconds,
+    IReadOnlyList<QuizQuestionDto> Questions);
+
+public sealed record QuizQuestionDto(
+    Guid Id,
+    string QuestionText,
+    QuestionType Type,
+    IReadOnlyList<string>? Options,
+    int OrderIndex);
+
+public sealed record QuizQuestionWithAnswerDto(
+    Guid Id,
+    string QuestionText,
+    QuestionType Type,
+    IReadOnlyList<string>? Options,
+    string CorrectAnswer,
+    string? Explanation,
+    int OrderIndex);
+
+public sealed record QuizAttemptDto(
+    Guid Id,
+    Guid QuizId,
+    int Score,
+    int TotalQuestions,
+    int DurationSeconds,
+    DateTime CompletedAt);
+
+public sealed record QuizAttemptDetailDto(
+    Guid Id,
+    Guid QuizId,
+    int Score,
+    int TotalQuestions,
+    int DurationSeconds,
+    DateTime CompletedAt,
+    IReadOnlyList<QuizAnswerDto> Answers);
+
+public sealed record QuizAnswerDto(
+    Guid QuestionId,
+    string QuestionText,
+    QuestionType Type,
+    string UserAnswer,
+    string CorrectAnswer,
+    string? Explanation,
+    bool IsCorrect);

--- a/src/Kursa.Domain/Entities/Quiz.cs
+++ b/src/Kursa.Domain/Entities/Quiz.cs
@@ -1,0 +1,22 @@
+namespace Kursa.Domain.Entities;
+
+public class Quiz : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public required string Title { get; set; }
+
+    public string? Topic { get; set; }
+
+    public Guid? ContentId { get; set; }
+
+    public int QuestionCount { get; set; }
+
+    public int DurationSeconds { get; set; }
+
+    public ICollection<QuizQuestion> Questions { get; init; } = new List<QuizQuestion>();
+
+    public ICollection<QuizAttempt> Attempts { get; init; } = new List<QuizAttempt>();
+}

--- a/src/Kursa.Domain/Entities/QuizAnswer.cs
+++ b/src/Kursa.Domain/Entities/QuizAnswer.cs
@@ -1,0 +1,16 @@
+namespace Kursa.Domain.Entities;
+
+public class QuizAnswer : BaseEntity
+{
+    public Guid AttemptId { get; set; }
+
+    public QuizAttempt Attempt { get; set; } = null!;
+
+    public Guid QuestionId { get; set; }
+
+    public QuizQuestion Question { get; set; } = null!;
+
+    public required string UserAnswer { get; set; }
+
+    public bool IsCorrect { get; set; }
+}

--- a/src/Kursa.Domain/Entities/QuizAttempt.cs
+++ b/src/Kursa.Domain/Entities/QuizAttempt.cs
@@ -1,0 +1,22 @@
+namespace Kursa.Domain.Entities;
+
+public class QuizAttempt : BaseEntity
+{
+    public Guid QuizId { get; set; }
+
+    public Quiz Quiz { get; set; } = null!;
+
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public int Score { get; set; }
+
+    public int TotalQuestions { get; set; }
+
+    public int DurationSeconds { get; set; }
+
+    public DateTime? CompletedAt { get; set; }
+
+    public ICollection<QuizAnswer> Answers { get; init; } = new List<QuizAnswer>();
+}

--- a/src/Kursa.Domain/Entities/QuizQuestion.cs
+++ b/src/Kursa.Domain/Entities/QuizQuestion.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace Kursa.Domain.Entities;
+
+public class QuizQuestion : BaseEntity
+{
+    public Guid QuizId { get; set; }
+
+    public Quiz Quiz { get; set; } = null!;
+
+    public required string QuestionText { get; set; }
+
+    public QuestionType Type { get; set; }
+
+    /// <summary>
+    /// JSON array of answer options (for multiple choice / true-false).
+    /// </summary>
+    public string? Options { get; set; }
+
+    public required string CorrectAnswer { get; set; }
+
+    public string? Explanation { get; set; }
+
+    public int OrderIndex { get; set; }
+}
+
+public enum QuestionType
+{
+    MultipleChoice,
+    TrueFalse,
+    FillInTheBlank,
+    OpenEnded,
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -41,6 +41,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/chat/chat.component').then((m) => m.ChatComponent),
       },
+      {
+        path: 'quizzes',
+        loadComponent: () =>
+          import('./features/quizzes/quizzes.component').then((m) => m.QuizzesComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/quiz.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/quiz.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Quiz {
+  id: string;
+  title: string;
+  topic: string | null;
+  questionCount: number;
+  durationSeconds: number;
+  attemptCount: number;
+  bestScore: number | null;
+  createdAt: string;
+}
+
+export interface QuizDetail {
+  id: string;
+  title: string;
+  topic: string | null;
+  durationSeconds: number;
+  questions: QuizQuestion[];
+}
+
+export interface QuizQuestion {
+  id: string;
+  questionText: string;
+  type: 'MultipleChoice' | 'TrueFalse' | 'FillInTheBlank' | 'OpenEnded';
+  options: string[] | null;
+  orderIndex: number;
+}
+
+export interface QuizAttemptDetail {
+  id: string;
+  quizId: string;
+  score: number;
+  totalQuestions: number;
+  durationSeconds: number;
+  completedAt: string;
+  answers: QuizAnswerResult[];
+}
+
+export interface QuizAnswerResult {
+  questionId: string;
+  questionText: string;
+  type: 'MultipleChoice' | 'TrueFalse' | 'FillInTheBlank' | 'OpenEnded';
+  userAnswer: string;
+  correctAnswer: string;
+  explanation: string | null;
+  isCorrect: boolean;
+}
+
+export interface QuizAttemptSummary {
+  id: string;
+  quizId: string;
+  score: number;
+  totalQuestions: number;
+  durationSeconds: number;
+  completedAt: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class QuizService {
+  private readonly http = inject(HttpClient);
+
+  getQuizzes(): Observable<Quiz[]> {
+    return this.http.get<Quiz[]>('/api/quizzes');
+  }
+
+  getQuizDetail(quizId: string): Observable<QuizDetail> {
+    return this.http.get<QuizDetail>(`/api/quizzes/${quizId}`);
+  }
+
+  generateQuiz(contentId: string, questionCount: number, topic?: string, durationSeconds = 600): Observable<QuizDetail> {
+    return this.http.post<QuizDetail>('/api/quizzes/generate', {
+      contentId,
+      questionCount,
+      topic,
+      durationSeconds,
+    });
+  }
+
+  submitAttempt(quizId: string, answers: { questionId: string; answer: string }[], durationSeconds: number): Observable<QuizAttemptDetail> {
+    return this.http.post<QuizAttemptDetail>(`/api/quizzes/${quizId}/submit`, {
+      answers,
+      durationSeconds,
+    });
+  }
+
+  getQuizResults(quizId: string): Observable<QuizAttemptSummary[]> {
+    return this.http.get<QuizAttemptSummary[]>(`/api/quizzes/${quizId}/results`);
+  }
+
+  getAttemptDetail(attemptId: string): Observable<QuizAttemptDetail> {
+    return this.http.get<QuizAttemptDetail>(`/api/quizzes/attempts/${attemptId}`);
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/quizzes/quizzes.component.ts
+++ b/src/Kursa.Frontend/src/app/features/quizzes/quizzes.component.ts
@@ -1,0 +1,664 @@
+import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit } from '@angular/core';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  Quiz,
+  QuizDetail,
+  QuizQuestion,
+  QuizAttemptDetail,
+  QuizAnswerResult,
+  QuizService,
+} from '../../core/services/quiz.service';
+import { PinnedContent, PinnedContentService } from '../../core/services/pinned-content.service';
+
+type View = 'list' | 'generate' | 'taking' | 'results';
+
+@Component({
+  selector: 'app-quizzes',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, DecimalPipe, FormsModule],
+  template: `
+    <div class="space-y-6">
+      @switch (view()) {
+        @case ('list') {
+          <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-bold text-foreground">Quizzes</h1>
+            <button
+              (click)="showGenerate()"
+              class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Generate Quiz
+            </button>
+          </div>
+
+          @if (loading()) {
+            <div class="flex items-center justify-center py-12">
+              <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+              <span class="ml-3 text-muted-foreground">Loading quizzes...</span>
+            </div>
+          } @else if (quizzes().length === 0) {
+            <div class="rounded-lg border border-border bg-card p-8 text-center">
+              <svg class="mx-auto h-12 w-12 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
+              </svg>
+              <h2 class="mt-4 text-lg font-semibold text-foreground">No quizzes yet</h2>
+              <p class="mt-2 text-sm text-muted-foreground">
+                Generate a quiz from your pinned course materials to test your knowledge.
+              </p>
+              <button
+                (click)="showGenerate()"
+                class="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Generate Your First Quiz
+              </button>
+            </div>
+          } @else {
+            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              @for (quiz of quizzes(); track quiz.id) {
+                <div class="rounded-lg border border-border bg-card p-5 transition-colors hover:border-primary/50">
+                  <h3 class="font-semibold text-foreground">{{ quiz.title }}</h3>
+                  @if (quiz.topic) {
+                    <p class="mt-1 text-xs text-muted-foreground">{{ quiz.topic }}</p>
+                  }
+                  <div class="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+                    <span>{{ quiz.questionCount }} questions</span>
+                    <span>{{ quiz.attemptCount }} attempt{{ quiz.attemptCount === 1 ? '' : 's' }}</span>
+                  </div>
+                  @if (quiz.bestScore !== null) {
+                    <div class="mt-2">
+                      <div class="flex items-center justify-between text-xs text-muted-foreground">
+                        <span>Best score</span>
+                        <span class="font-medium" [class]="quiz.bestScore >= quiz.questionCount * 0.7 ? 'text-green-500' : 'text-orange-500'">
+                          {{ quiz.bestScore }}/{{ quiz.questionCount }}
+                        </span>
+                      </div>
+                      <div class="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                        <div
+                          class="h-full rounded-full transition-all"
+                          [class]="quiz.bestScore >= quiz.questionCount * 0.7 ? 'bg-green-500' : 'bg-orange-500'"
+                          [style.width.%]="(quiz.bestScore / quiz.questionCount) * 100"
+                        ></div>
+                      </div>
+                    </div>
+                  }
+                  <div class="mt-4 flex gap-2">
+                    <button
+                      (click)="startQuiz(quiz.id)"
+                      class="flex-1 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                    >
+                      Take Quiz
+                    </button>
+                    <button
+                      (click)="viewResults(quiz.id)"
+                      class="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
+                      [disabled]="quiz.attemptCount === 0"
+                      [class.opacity-50]="quiz.attemptCount === 0"
+                    >
+                      Results
+                    </button>
+                  </div>
+                  <p class="mt-2 text-xs text-muted-foreground">{{ quiz.createdAt | date:'mediumDate' }}</p>
+                </div>
+              }
+            </div>
+          }
+        }
+
+        @case ('generate') {
+          <div class="flex items-center gap-3">
+            <button
+              (click)="view.set('list')"
+              class="rounded-md p-2 text-muted-foreground hover:bg-accent"
+              aria-label="Back to quizzes"
+            >
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+              </svg>
+            </button>
+            <h1 class="text-2xl font-bold text-foreground">Generate Quiz</h1>
+          </div>
+
+          @if (loadingPinned()) {
+            <div class="flex items-center justify-center py-12">
+              <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+              <span class="ml-3 text-muted-foreground">Loading pinned content...</span>
+            </div>
+          } @else if (pinnedItems().length === 0) {
+            <div class="rounded-lg border border-border bg-card p-8 text-center">
+              <h2 class="mt-4 text-lg font-semibold text-foreground">No pinned content</h2>
+              <p class="mt-2 text-sm text-muted-foreground">
+                Pin and index some course materials first to generate quizzes.
+              </p>
+            </div>
+          } @else {
+            <div class="mx-auto max-w-lg space-y-6 rounded-lg border border-border bg-card p-6">
+              <div>
+                <label for="content-select" class="block text-sm font-medium text-foreground">Select Material</label>
+                <select
+                  id="content-select"
+                  [(ngModel)]="selectedContentId"
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <option value="">Choose pinned content...</option>
+                  @for (item of indexedItems(); track item.contentId) {
+                    <option [value]="item.contentId">{{ item.contentTitle }}</option>
+                  }
+                </select>
+              </div>
+              <div>
+                <label for="question-count" class="block text-sm font-medium text-foreground">Number of Questions</label>
+                <input
+                  id="question-count"
+                  type="number"
+                  [(ngModel)]="questionCount"
+                  min="1"
+                  max="50"
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div>
+                <label for="topic" class="block text-sm font-medium text-foreground">Topic (optional)</label>
+                <input
+                  id="topic"
+                  type="text"
+                  [(ngModel)]="topicInput"
+                  placeholder="Focus on a specific topic..."
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div>
+                <label for="duration" class="block text-sm font-medium text-foreground">Time Limit (minutes)</label>
+                <input
+                  id="duration"
+                  type="number"
+                  [(ngModel)]="durationMinutes"
+                  min="1"
+                  max="120"
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              @if (error()) {
+                <div class="rounded-md border border-destructive/50 bg-destructive/10 p-3">
+                  <p class="text-sm text-destructive">{{ error() }}</p>
+                </div>
+              }
+
+              <button
+                (click)="generateQuiz()"
+                [disabled]="generating() || !selectedContentId"
+                class="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                @if (generating()) {
+                  <span class="flex items-center justify-center gap-2">
+                    <span class="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent"></span>
+                    Generating quiz...
+                  </span>
+                } @else {
+                  Generate Quiz
+                }
+              </button>
+            </div>
+          }
+        }
+
+        @case ('taking') {
+          @if (currentQuiz()) {
+            <div class="mx-auto max-w-2xl space-y-6">
+              <div class="flex items-center justify-between">
+                <h1 class="text-xl font-bold text-foreground">{{ currentQuiz()!.title }}</h1>
+                <div class="flex items-center gap-3">
+                  <span class="text-sm text-muted-foreground">
+                    {{ currentQuestionIndex() + 1 }}/{{ currentQuiz()!.questions.length }}
+                  </span>
+                  <span class="rounded-md bg-muted px-3 py-1 text-sm font-medium text-foreground">
+                    {{ formattedTimer() }}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Progress bar -->
+              <div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full bg-primary transition-all"
+                  [style.width.%]="((currentQuestionIndex() + 1) / currentQuiz()!.questions.length) * 100"
+                ></div>
+              </div>
+
+              @if (currentQuestion(); as q) {
+                <div class="rounded-lg border border-border bg-card p-6">
+                  <p class="text-lg font-medium text-foreground">{{ q.questionText }}</p>
+
+                  <div class="mt-6 space-y-3">
+                    @switch (q.type) {
+                      @case ('MultipleChoice') {
+                        @if (q.options) {
+                          @for (option of q.options; track option; let i = $index) {
+                            <button
+                              (click)="selectAnswer(option)"
+                              class="flex w-full items-center gap-3 rounded-md border p-3 text-left text-sm transition-colors"
+                              [class]="answers()[q.id] === option
+                                ? 'border-primary bg-primary/10 text-foreground'
+                                : 'border-border text-muted-foreground hover:border-primary/50 hover:bg-accent'"
+                            >
+                              <span
+                                class="flex h-6 w-6 items-center justify-center rounded-full border text-xs font-medium"
+                                [class]="answers()[q.id] === option
+                                  ? 'border-primary bg-primary text-primary-foreground'
+                                  : 'border-border'"
+                              >
+                                {{ ['A','B','C','D'][i] }}
+                              </span>
+                              {{ option }}
+                            </button>
+                          }
+                        }
+                      }
+                      @case ('TrueFalse') {
+                        <div class="flex gap-3">
+                          @for (option of ['True', 'False']; track option) {
+                            <button
+                              (click)="selectAnswer(option)"
+                              class="flex-1 rounded-md border p-3 text-center text-sm font-medium transition-colors"
+                              [class]="answers()[q.id] === option
+                                ? 'border-primary bg-primary/10 text-foreground'
+                                : 'border-border text-muted-foreground hover:border-primary/50 hover:bg-accent'"
+                            >
+                              {{ option }}
+                            </button>
+                          }
+                        </div>
+                      }
+                      @case ('FillInTheBlank') {
+                        <input
+                          type="text"
+                          [value]="answers()[q.id] || ''"
+                          (input)="onInputAnswer($event)"
+                          placeholder="Type your answer..."
+                          class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                        />
+                      }
+                      @default {
+                        <textarea
+                          [value]="answers()[q.id] || ''"
+                          (input)="onInputAnswer($event)"
+                          placeholder="Write your answer..."
+                          rows="4"
+                          class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                        ></textarea>
+                      }
+                    }
+                  </div>
+                </div>
+
+                <div class="flex justify-between">
+                  <button
+                    (click)="prevQuestion()"
+                    [disabled]="currentQuestionIndex() === 0"
+                    class="rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent disabled:opacity-50"
+                  >
+                    Previous
+                  </button>
+                  @if (currentQuestionIndex() < currentQuiz()!.questions.length - 1) {
+                    <button
+                      (click)="nextQuestion()"
+                      class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                    >
+                      Next
+                    </button>
+                  } @else {
+                    <button
+                      (click)="submitQuiz()"
+                      [disabled]="submitting()"
+                      class="rounded-md bg-green-600 px-6 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+                    >
+                      @if (submitting()) {
+                        Submitting...
+                      } @else {
+                        Submit Quiz
+                      }
+                    </button>
+                  }
+                </div>
+              }
+            </div>
+          }
+        }
+
+        @case ('results') {
+          @if (attemptResult()) {
+            <div class="mx-auto max-w-2xl space-y-6">
+              <div class="flex items-center gap-3">
+                <button
+                  (click)="backToList()"
+                  class="rounded-md p-2 text-muted-foreground hover:bg-accent"
+                  aria-label="Back to quizzes"
+                >
+                  <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+                  </svg>
+                </button>
+                <h1 class="text-2xl font-bold text-foreground">Quiz Results</h1>
+              </div>
+
+              <!-- Score card -->
+              <div class="rounded-lg border border-border bg-card p-6 text-center">
+                <div
+                  class="mx-auto flex h-24 w-24 items-center justify-center rounded-full"
+                  [class]="scorePercentage() >= 70 ? 'bg-green-500/10' : scorePercentage() >= 40 ? 'bg-orange-500/10' : 'bg-destructive/10'"
+                >
+                  <span
+                    class="text-3xl font-bold"
+                    [class]="scorePercentage() >= 70 ? 'text-green-500' : scorePercentage() >= 40 ? 'text-orange-500' : 'text-destructive'"
+                  >
+                    {{ scorePercentage() | number:'1.0-0' }}%
+                  </span>
+                </div>
+                <p class="mt-3 text-lg font-semibold text-foreground">
+                  {{ attemptResult()!.score }}/{{ attemptResult()!.totalQuestions }} correct
+                </p>
+                <p class="mt-1 text-sm text-muted-foreground">
+                  @if (scorePercentage() >= 90) {
+                    Excellent work!
+                  } @else if (scorePercentage() >= 70) {
+                    Good job!
+                  } @else if (scorePercentage() >= 40) {
+                    Keep studying!
+                  } @else {
+                    Review the material and try again.
+                  }
+                </p>
+              </div>
+
+              <!-- Answer review -->
+              <div class="space-y-4">
+                <h2 class="text-lg font-semibold text-foreground">Review</h2>
+                @for (answer of attemptResult()!.answers; track answer.questionId; let i = $index) {
+                  <div
+                    class="rounded-lg border p-4"
+                    [class]="answer.isCorrect ? 'border-green-500/30 bg-green-500/5' : 'border-destructive/30 bg-destructive/5'"
+                  >
+                    <div class="flex items-start gap-3">
+                      <span
+                        class="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium text-white"
+                        [class]="answer.isCorrect ? 'bg-green-500' : 'bg-destructive'"
+                      >
+                        @if (answer.isCorrect) {
+                          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+                        } @else {
+                          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+                        }
+                      </span>
+                      <div class="flex-1">
+                        <p class="font-medium text-foreground">{{ answer.questionText }}</p>
+                        <p class="mt-1 text-sm">
+                          <span class="text-muted-foreground">Your answer: </span>
+                          <span [class]="answer.isCorrect ? 'text-green-500' : 'text-destructive'">{{ answer.userAnswer || '(no answer)' }}</span>
+                        </p>
+                        @if (!answer.isCorrect) {
+                          <p class="mt-1 text-sm">
+                            <span class="text-muted-foreground">Correct answer: </span>
+                            <span class="text-green-500">{{ answer.correctAnswer }}</span>
+                          </p>
+                        }
+                        @if (answer.explanation) {
+                          <p class="mt-2 text-sm text-muted-foreground">{{ answer.explanation }}</p>
+                        }
+                      </div>
+                    </div>
+                  </div>
+                }
+              </div>
+
+              <div class="flex gap-3">
+                <button
+                  (click)="retakeQuiz()"
+                  class="flex-1 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  Retake Quiz
+                </button>
+                <button
+                  (click)="backToList()"
+                  class="flex-1 rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent"
+                >
+                  Back to Quizzes
+                </button>
+              </div>
+            </div>
+          }
+        }
+      }
+    </div>
+  `,
+})
+export class QuizzesComponent implements OnInit {
+  private readonly quizService = inject(QuizService);
+  private readonly pinnedService = inject(PinnedContentService);
+
+  readonly view = signal<View>('list');
+  readonly loading = signal(true);
+  readonly generating = signal(false);
+  readonly submitting = signal(false);
+  readonly error = signal<string | null>(null);
+
+  readonly quizzes = signal<Quiz[]>([]);
+  readonly pinnedItems = signal<PinnedContent[]>([]);
+  readonly loadingPinned = signal(false);
+
+  // Generate form
+  selectedContentId = '';
+  questionCount = 10;
+  topicInput = '';
+  durationMinutes = 10;
+
+  // Quiz taking
+  readonly currentQuiz = signal<QuizDetail | null>(null);
+  readonly currentQuestionIndex = signal(0);
+  readonly answers = signal<Record<string, string>>({});
+  readonly timerSeconds = signal(0);
+  private timerInterval: ReturnType<typeof setInterval> | null = null;
+
+  // Results
+  readonly attemptResult = signal<QuizAttemptDetail | null>(null);
+
+  readonly indexedItems = computed(() => this.pinnedItems().filter((p) => p.isIndexed));
+
+  readonly currentQuestion = computed(() => {
+    const quiz = this.currentQuiz();
+    if (!quiz) return null;
+    return quiz.questions[this.currentQuestionIndex()] ?? null;
+  });
+
+  readonly formattedTimer = computed(() => {
+    const total = this.timerSeconds();
+    const minutes = Math.floor(total / 60);
+    const seconds = total % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  });
+
+  readonly scorePercentage = computed(() => {
+    const result = this.attemptResult();
+    if (!result || result.totalQuestions === 0) return 0;
+    return (result.score / result.totalQuestions) * 100;
+  });
+
+  ngOnInit(): void {
+    this.loadQuizzes();
+  }
+
+  loadQuizzes(): void {
+    this.loading.set(true);
+    this.quizService.getQuizzes().subscribe({
+      next: (quizzes) => {
+        this.quizzes.set(quizzes);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to load quizzes.';
+        this.error.set(message);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  showGenerate(): void {
+    this.view.set('generate');
+    this.error.set(null);
+    if (this.pinnedItems().length === 0) {
+      this.loadingPinned.set(true);
+      this.pinnedService.getPinnedContents().subscribe({
+        next: (items) => {
+          this.pinnedItems.set(items);
+          this.loadingPinned.set(false);
+        },
+        error: () => {
+          this.loadingPinned.set(false);
+        },
+      });
+    }
+  }
+
+  generateQuiz(): void {
+    if (!this.selectedContentId) return;
+    this.generating.set(true);
+    this.error.set(null);
+
+    const topic = this.topicInput.trim() || undefined;
+    const durationSeconds = this.durationMinutes * 60;
+
+    this.quizService.generateQuiz(this.selectedContentId, this.questionCount, topic, durationSeconds).subscribe({
+      next: (quiz) => {
+        this.generating.set(false);
+        this.currentQuiz.set(quiz);
+        this.currentQuestionIndex.set(0);
+        this.answers.set({});
+        this.startTimer(quiz.durationSeconds);
+        this.view.set('taking');
+      },
+      error: (err) => {
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to generate quiz.';
+        this.error.set(message);
+        this.generating.set(false);
+      },
+    });
+  }
+
+  startQuiz(quizId: string): void {
+    this.loading.set(true);
+    this.quizService.getQuizDetail(quizId).subscribe({
+      next: (quiz) => {
+        this.currentQuiz.set(quiz);
+        this.currentQuestionIndex.set(0);
+        this.answers.set({});
+        this.startTimer(quiz.durationSeconds);
+        this.view.set('taking');
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+      },
+    });
+  }
+
+  selectAnswer(answer: string): void {
+    const q = this.currentQuestion();
+    if (!q) return;
+    this.answers.update((prev) => ({ ...prev, [q.id]: answer }));
+  }
+
+  onInputAnswer(event: Event): void {
+    const target = event.target as HTMLInputElement | HTMLTextAreaElement;
+    this.selectAnswer(target.value);
+  }
+
+  nextQuestion(): void {
+    const quiz = this.currentQuiz();
+    if (!quiz) return;
+    if (this.currentQuestionIndex() < quiz.questions.length - 1) {
+      this.currentQuestionIndex.update((i) => i + 1);
+    }
+  }
+
+  prevQuestion(): void {
+    if (this.currentQuestionIndex() > 0) {
+      this.currentQuestionIndex.update((i) => i - 1);
+    }
+  }
+
+  submitQuiz(): void {
+    const quiz = this.currentQuiz();
+    if (!quiz) return;
+
+    this.submitting.set(true);
+    this.stopTimer();
+
+    const elapsed = quiz.durationSeconds - this.timerSeconds();
+    const answerList = quiz.questions.map((q) => ({
+      questionId: q.id,
+      answer: this.answers()[q.id] ?? '',
+    }));
+
+    this.quizService.submitAttempt(quiz.id, answerList, elapsed).subscribe({
+      next: (result) => {
+        this.attemptResult.set(result);
+        this.submitting.set(false);
+        this.view.set('results');
+        this.loadQuizzes(); // Refresh list in background
+      },
+      error: (err) => {
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to submit quiz.';
+        this.error.set(message);
+        this.submitting.set(false);
+      },
+    });
+  }
+
+  viewResults(quizId: string): void {
+    this.quizService.getQuizResults(quizId).subscribe({
+      next: (attempts) => {
+        if (attempts.length > 0) {
+          this.quizService.getAttemptDetail(attempts[0].id).subscribe({
+            next: (detail) => {
+              this.attemptResult.set(detail);
+              this.view.set('results');
+            },
+          });
+        }
+      },
+    });
+  }
+
+  retakeQuiz(): void {
+    const result = this.attemptResult();
+    if (result) {
+      this.startQuiz(result.quizId);
+    }
+  }
+
+  backToList(): void {
+    this.stopTimer();
+    this.view.set('list');
+    this.loadQuizzes();
+  }
+
+  private startTimer(totalSeconds: number): void {
+    this.stopTimer();
+    this.timerSeconds.set(totalSeconds);
+    this.timerInterval = setInterval(() => {
+      this.timerSeconds.update((s) => {
+        if (s <= 0) {
+          this.submitQuiz();
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+  }
+
+  private stopTimer(): void {
+    if (this.timerInterval) {
+      clearInterval(this.timerInterval);
+      this.timerInterval = null;
+    }
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -57,12 +57,12 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           AI Chat
         </a>
         <a
-          routerLink="/study"
+          routerLink="/quizzes"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.9-4 6.5C6 11.1 5 13 5 15a7 7 0 0 0 7 7z" /></svg>
-          Study Tools
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75" /><path d="M12 17.25h.008v.008H12z" /><circle cx="12" cy="12" r="10" /></svg>
+          Quizzes
         </a>
         <a
           routerLink="/settings"

--- a/src/Kursa.Infrastructure/Migrations/20260310215245_AddQuizEntities.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310215245_AddQuizEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310215245_AddQuizEntities")]
+    partial class AddQuizEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310215245_AddQuizEntities.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310215245_AddQuizEntities.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQuizEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Quizzes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Topic = table.Column<string>(type: "text", nullable: true),
+                    ContentId = table.Column<Guid>(type: "uuid", nullable: true),
+                    QuestionCount = table.Column<int>(type: "integer", nullable: false),
+                    DurationSeconds = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Quizzes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Quizzes_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "QuizAttempts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    QuizId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Score = table.Column<int>(type: "integer", nullable: false),
+                    TotalQuestions = table.Column<int>(type: "integer", nullable: false),
+                    DurationSeconds = table.Column<int>(type: "integer", nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_QuizAttempts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_QuizAttempts_Quizzes_QuizId",
+                        column: x => x.QuizId,
+                        principalTable: "Quizzes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_QuizAttempts_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "QuizQuestions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    QuizId = table.Column<Guid>(type: "uuid", nullable: false),
+                    QuestionText = table.Column<string>(type: "text", nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Options = table.Column<string>(type: "text", nullable: true),
+                    CorrectAnswer = table.Column<string>(type: "text", nullable: false),
+                    Explanation = table.Column<string>(type: "text", nullable: true),
+                    OrderIndex = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_QuizQuestions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_QuizQuestions_Quizzes_QuizId",
+                        column: x => x.QuizId,
+                        principalTable: "Quizzes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "QuizAnswers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AttemptId = table.Column<Guid>(type: "uuid", nullable: false),
+                    QuestionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserAnswer = table.Column<string>(type: "text", nullable: false),
+                    IsCorrect = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_QuizAnswers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_QuizAnswers_QuizAttempts_AttemptId",
+                        column: x => x.AttemptId,
+                        principalTable: "QuizAttempts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_QuizAnswers_QuizQuestions_QuestionId",
+                        column: x => x.QuestionId,
+                        principalTable: "QuizQuestions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizAnswers_AttemptId",
+                table: "QuizAnswers",
+                column: "AttemptId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizAnswers_QuestionId",
+                table: "QuizAnswers",
+                column: "QuestionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizAttempts_QuizId",
+                table: "QuizAttempts",
+                column: "QuizId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizAttempts_UserId",
+                table: "QuizAttempts",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizQuestions_QuizId",
+                table: "QuizQuestions",
+                column: "QuizId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Quizzes_UserId",
+                table: "Quizzes",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "QuizAnswers");
+
+            migrationBuilder.DropTable(
+                name: "QuizAttempts");
+
+            migrationBuilder.DropTable(
+                name: "QuizQuestions");
+
+            migrationBuilder.DropTable(
+                name: "Quizzes");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -24,6 +24,14 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
 
+    public DbSet<Quiz> Quizzes => Set<Quiz>();
+
+    public DbSet<QuizQuestion> QuizQuestions => Set<QuizQuestion>();
+
+    public DbSet<QuizAttempt> QuizAttempts => Set<QuizAttempt>();
+
+    public DbSet<QuizAnswer> QuizAnswers => Set<QuizAnswer>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);


### PR DESCRIPTION
## Summary
- **Domain**: Quiz, QuizQuestion, QuizAttempt, QuizAnswer entities with EF Core migration
- **Backend**: CQRS commands (GenerateQuiz via LLM + RAG, SubmitQuizAttempt) and queries (list, detail, results, attempt detail) with API controller
- **Frontend**: Full quiz UI — list view with cards, generate form (select pinned content, question count, topic, duration), quiz-taking interface with timer and progress bar, and results review with explanations
- **Navigation**: Sidebar updated with Quizzes link replacing the Study Tools placeholder

## Test plan
- [ ] Generate a quiz from pinned & indexed content — verify questions are generated via LLM
- [ ] Take a quiz — verify timer, question navigation, answer selection work
- [ ] Submit quiz — verify scoring and results display with explanations
- [ ] Retake quiz — verify quiz can be retaken with fresh answers
- [ ] View quiz list — verify cards show attempt count and best score
- [ ] Visually verified via Playwright: empty state, generate form, sidebar active state

Closes #13