### PR TITLE
feat(flashcards): add flashcard engine with SM-2 spaced repetition

### DIFF
--- a/src/Kursa.API/Controllers/FlashcardsController.cs
+++ b/src/Kursa.API/Controllers/FlashcardsController.cs
@@ -1,0 +1,87 @@
+using Kursa.Application.Features.Flashcards.Commands;
+using Kursa.Application.Features.Flashcards.Queries;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/flashcards")]
+[Authorize]
+public class FlashcardsController(ISender sender) : ControllerBase
+{
+    [HttpGet("decks")]
+    public async Task<IActionResult> GetDecksAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetDecksQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("decks/{deckId:guid}")]
+    public async Task<IActionResult> GetDeckDetailAsync(Guid deckId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetDeckDetailQuery(deckId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : NotFound(result.Error);
+    }
+
+    [HttpGet("decks/{deckId:guid}/due")]
+    public async Task<IActionResult> GetDueCardsAsync(Guid deckId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetDueFlashcardsQuery(deckId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : NotFound(result.Error);
+    }
+
+    [HttpPost("generate")]
+    public async Task<IActionResult> GenerateFlashcardsAsync([FromBody] GenerateFlashcardsRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GenerateFlashcardsCommand(
+            request.ContentId,
+            request.CardCount,
+            request.Topic), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("decks/{deckId:guid}/cards")]
+    public async Task<IActionResult> CreateCardAsync(Guid deckId, [FromBody] CreateCardRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new CreateFlashcardCommand(
+            deckId,
+            request.Front,
+            request.Back,
+            request.Type), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("cards/{cardId:guid}/review")]
+    public async Task<IActionResult> ReviewCardAsync(Guid cardId, [FromBody] ReviewCardRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new ReviewFlashcardCommand(cardId, request.Quality), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+}
+
+public sealed record GenerateFlashcardsRequest(Guid ContentId, int CardCount = 20, string? Topic = null);
+
+public sealed record CreateCardRequest(string Front, string Back, FlashcardType Type = FlashcardType.Basic);
+
+public sealed record ReviewCardRequest(int Quality);

--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -31,5 +31,9 @@ public interface IAppDbContext
 
     DbSet<QuizAnswer> QuizAnswers { get; }
 
+    DbSet<FlashcardDeck> FlashcardDecks { get; }
+
+    DbSet<Flashcard> Flashcards { get; }
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Flashcards/Commands/CreateFlashcard.cs
+++ b/src/Kursa.Application/Features/Flashcards/Commands/CreateFlashcard.cs
@@ -1,0 +1,64 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Flashcards.Commands;
+
+public sealed record CreateFlashcardCommand(
+    Guid DeckId,
+    string Front,
+    string Back,
+    FlashcardType Type = FlashcardType.Basic) : IRequest<Result<FlashcardDto>>;
+
+public sealed class CreateFlashcardValidator : AbstractValidator<CreateFlashcardCommand>
+{
+    public CreateFlashcardValidator()
+    {
+        RuleFor(x => x.DeckId).NotEmpty();
+        RuleFor(x => x.Front).NotEmpty().MaximumLength(2000);
+        RuleFor(x => x.Back).NotEmpty().MaximumLength(2000);
+    }
+}
+
+public sealed class CreateFlashcardHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<CreateFlashcardCommand, Result<FlashcardDto>>
+{
+    public async Task<Result<FlashcardDto>> Handle(CreateFlashcardCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<FlashcardDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<FlashcardDto>.Failure("User not found.");
+
+        bool deckExists = await dbContext.FlashcardDecks
+            .AnyAsync(d => d.Id == request.DeckId && d.UserId == user.Id, cancellationToken);
+
+        if (!deckExists)
+            return Result<FlashcardDto>.Failure("Deck not found.");
+
+        var card = new Flashcard
+        {
+            DeckId = request.DeckId,
+            Front = request.Front,
+            Back = request.Back,
+            Type = request.Type,
+            NextReviewAt = DateTime.UtcNow,
+        };
+
+        dbContext.Flashcards.Add(card);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<FlashcardDto>.Success(new FlashcardDto(
+            card.Id, card.Front, card.Back, card.Type,
+            card.Repetitions, card.EaseFactor, card.IntervalDays,
+            card.NextReviewAt, card.LastReviewedAt));
+    }
+}

--- a/src/Kursa.Application/Features/Flashcards/Commands/GenerateFlashcards.cs
+++ b/src/Kursa.Application/Features/Flashcards/Commands/GenerateFlashcards.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Application.Features.Flashcards.Commands;
+
+public sealed record GenerateFlashcardsCommand(
+    Guid ContentId,
+    int CardCount = 20,
+    string? Topic = null) : IRequest<Result<FlashcardDeckDetailDto>>;
+
+public sealed class GenerateFlashcardsValidator : AbstractValidator<GenerateFlashcardsCommand>
+{
+    public GenerateFlashcardsValidator()
+    {
+        RuleFor(x => x.ContentId).NotEmpty();
+        RuleFor(x => x.CardCount).InclusiveBetween(1, 100);
+    }
+}
+
+public sealed class GenerateFlashcardsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    ILlmProvider llmProvider,
+    IVectorStore vectorStore,
+    ILogger<GenerateFlashcardsHandler> logger) : IRequestHandler<GenerateFlashcardsCommand, Result<FlashcardDeckDetailDto>>
+{
+    private const string CollectionName = "content_chunks";
+
+    private const string SystemPrompt =
+        """
+        You are a flashcard generator for educational materials. Generate flashcards based on the provided content.
+
+        Rules:
+        - Generate exactly the requested number of flashcards.
+        - Mix types: "basic" (question/answer), "cloze" (fill in blank with "{{c1::answer}}" syntax on front), "reversible" (both sides are meaningful).
+        - Focus on key concepts, definitions, and important facts.
+        - Keep fronts concise and specific.
+        - Backs should be clear and complete but not overly long.
+        - Write in the same language as the source material.
+
+        Respond ONLY with valid JSON in this exact format:
+        {
+          "cards": [
+            {
+              "front": "What is...?",
+              "back": "The answer is...",
+              "type": "basic"
+            }
+          ]
+        }
+        """;
+
+    public async Task<Result<FlashcardDeckDetailDto>> Handle(GenerateFlashcardsCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<FlashcardDeckDetailDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<FlashcardDeckDetailDto>.Failure("User not found.");
+
+        var pinnedContent = await dbContext.PinnedContents
+            .Include(p => p.Content)
+            .FirstOrDefaultAsync(p => p.ContentId == request.ContentId && p.UserId == user.Id, cancellationToken);
+
+        if (pinnedContent is null)
+            return Result<FlashcardDeckDetailDto>.Failure("Content must be pinned before generating flashcards.");
+
+        if (!pinnedContent.IsIndexed)
+            return Result<FlashcardDeckDetailDto>.Failure("Content must be indexed first.");
+
+        string searchQuery = request.Topic ?? pinnedContent.Content.Title;
+        IReadOnlyList<float> queryEmbedding = await llmProvider.GenerateEmbeddingAsync(searchQuery, cancellationToken);
+
+        IReadOnlyList<VectorSearchResult> searchResults = await vectorStore.SearchAsync(
+            CollectionName,
+            queryEmbedding,
+            limit: 10,
+            filterByUserId: user.Id,
+            filterByContentId: request.ContentId,
+            cancellationToken: cancellationToken);
+
+        if (searchResults.Count == 0)
+            return Result<FlashcardDeckDetailDto>.Failure("No indexed content found.");
+
+        string context = string.Join("\n\n---\n\n", searchResults.Select(r => r.ChunkText));
+
+        string userPrompt = $"""
+            Generate {request.CardCount} flashcards from the following material:
+
+            {context}
+
+            {(request.Topic is not null ? $"Focus on: {request.Topic}" : "Cover the main concepts.")}
+            """;
+
+        try
+        {
+            LlmChatResponse llmResponse = await llmProvider.ChatAsync(new LlmChatRequest
+            {
+                SystemPrompt = SystemPrompt,
+                Messages = [LlmMessage.User(userPrompt)],
+                Temperature = 0.5f,
+                MaxTokens = 4096,
+            }, cancellationToken);
+
+            var cards = ParseFlashcardResponse(llmResponse.Content);
+
+            if (cards.Count == 0)
+                return Result<FlashcardDeckDetailDto>.Failure("Failed to generate flashcards. Please try again.");
+
+            var deck = new FlashcardDeck
+            {
+                UserId = user.Id,
+                Title = request.Topic is not null
+                    ? $"Flashcards: {request.Topic}"
+                    : $"Flashcards: {pinnedContent.Content.Title}",
+                Description = request.Topic,
+                ContentId = request.ContentId,
+            };
+
+            foreach (var card in cards)
+            {
+                deck.Cards.Add(new Flashcard
+                {
+                    DeckId = deck.Id,
+                    Front = card.Front,
+                    Back = card.Back,
+                    Type = card.Type,
+                    NextReviewAt = DateTime.UtcNow,
+                });
+            }
+
+            dbContext.FlashcardDecks.Add(deck);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            var cardDtos = deck.Cards.Select(c => new FlashcardDto(
+                c.Id, c.Front, c.Back, c.Type,
+                c.Repetitions, c.EaseFactor, c.IntervalDays,
+                c.NextReviewAt, c.LastReviewedAt)).ToList();
+
+            return Result<FlashcardDeckDetailDto>.Success(new FlashcardDeckDetailDto(
+                deck.Id, deck.Title, deck.Description, cardDtos));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to generate flashcards for content {ContentId}", request.ContentId);
+            return Result<FlashcardDeckDetailDto>.Failure("Failed to generate flashcards. Please try again.");
+        }
+    }
+
+    private static List<GeneratedCard> ParseFlashcardResponse(string content)
+    {
+        var result = new List<GeneratedCard>();
+
+        try
+        {
+            string json = content;
+            int jsonStart = json.IndexOf('{');
+            int jsonEnd = json.LastIndexOf('}');
+            if (jsonStart >= 0 && jsonEnd > jsonStart)
+                json = json[jsonStart..(jsonEnd + 1)];
+
+            using var doc = JsonDocument.Parse(json);
+            JsonElement cards = doc.RootElement.GetProperty("cards");
+
+            foreach (JsonElement c in cards.EnumerateArray())
+            {
+                string typeStr = c.TryGetProperty("type", out JsonElement typeEl) ? typeEl.GetString() ?? "basic" : "basic";
+                FlashcardType type = typeStr switch
+                {
+                    "cloze" => FlashcardType.Cloze,
+                    "reversible" => FlashcardType.Reversible,
+                    _ => FlashcardType.Basic,
+                };
+
+                result.Add(new GeneratedCard(
+                    c.GetProperty("front").GetString() ?? string.Empty,
+                    c.GetProperty("back").GetString() ?? string.Empty,
+                    type));
+            }
+        }
+        catch (JsonException)
+        {
+            // Return empty on parse failure
+        }
+
+        return result;
+    }
+
+    private sealed record GeneratedCard(string Front, string Back, FlashcardType Type);
+}

--- a/src/Kursa.Application/Features/Flashcards/Commands/ReviewFlashcard.cs
+++ b/src/Kursa.Application/Features/Flashcards/Commands/ReviewFlashcard.cs
@@ -1,0 +1,90 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Flashcards.Commands;
+
+/// <summary>
+/// SM-2 quality rating: 0 = complete blackout, 5 = perfect response.
+/// </summary>
+public sealed record ReviewFlashcardCommand(Guid CardId, int Quality) : IRequest<Result<ReviewResultDto>>;
+
+public sealed class ReviewFlashcardValidator : AbstractValidator<ReviewFlashcardCommand>
+{
+    public ReviewFlashcardValidator()
+    {
+        RuleFor(x => x.CardId).NotEmpty();
+        RuleFor(x => x.Quality).InclusiveBetween(0, 5);
+    }
+}
+
+public sealed class ReviewFlashcardHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<ReviewFlashcardCommand, Result<ReviewResultDto>>
+{
+    public async Task<Result<ReviewResultDto>> Handle(ReviewFlashcardCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<ReviewResultDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<ReviewResultDto>.Failure("User not found.");
+
+        var card = await dbContext.Flashcards
+            .Include(c => c.Deck)
+            .FirstOrDefaultAsync(c => c.Id == request.CardId && c.Deck.UserId == user.Id, cancellationToken);
+
+        if (card is null)
+            return Result<ReviewResultDto>.Failure("Flashcard not found.");
+
+        // SM-2 Algorithm
+        ApplySm2(card, request.Quality);
+        card.LastReviewedAt = DateTime.UtcNow;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<ReviewResultDto>.Success(new ReviewResultDto(
+            card.Id,
+            card.Repetitions,
+            card.EaseFactor,
+            card.IntervalDays,
+            card.NextReviewAt ?? DateTime.UtcNow));
+    }
+
+    /// <summary>
+    /// Implements the SM-2 spaced repetition algorithm.
+    /// quality: 0-5 where 0 = complete blackout, 5 = perfect response
+    /// </summary>
+    private static void ApplySm2(Flashcard card, int quality)
+    {
+        // Update ease factor
+        float newEf = card.EaseFactor + (0.1f - (5 - quality) * (0.08f + (5 - quality) * 0.02f));
+        card.EaseFactor = Math.Max(1.3f, newEf);
+
+        if (quality < 3)
+        {
+            // Failed: reset repetitions
+            card.Repetitions = 0;
+            card.IntervalDays = 1;
+        }
+        else
+        {
+            card.Repetitions++;
+
+            card.IntervalDays = card.Repetitions switch
+            {
+                1 => 1,
+                2 => 6,
+                _ => (int)Math.Round(card.IntervalDays * card.EaseFactor),
+            };
+        }
+
+        card.NextReviewAt = DateTime.UtcNow.AddDays(card.IntervalDays);
+    }
+}

--- a/src/Kursa.Application/Features/Flashcards/FlashcardDtos.cs
+++ b/src/Kursa.Application/Features/Flashcards/FlashcardDtos.cs
@@ -1,0 +1,35 @@
+using Kursa.Domain.Entities;
+
+namespace Kursa.Application.Features.Flashcards;
+
+public sealed record FlashcardDeckDto(
+    Guid Id,
+    string Title,
+    string? Description,
+    int CardCount,
+    int DueCount,
+    DateTime CreatedAt);
+
+public sealed record FlashcardDeckDetailDto(
+    Guid Id,
+    string Title,
+    string? Description,
+    IReadOnlyList<FlashcardDto> Cards);
+
+public sealed record FlashcardDto(
+    Guid Id,
+    string Front,
+    string Back,
+    FlashcardType Type,
+    int Repetitions,
+    float EaseFactor,
+    int IntervalDays,
+    DateTime? NextReviewAt,
+    DateTime? LastReviewedAt);
+
+public sealed record ReviewResultDto(
+    Guid CardId,
+    int NewRepetitions,
+    float NewEaseFactor,
+    int NewIntervalDays,
+    DateTime NextReviewAt);

--- a/src/Kursa.Application/Features/Flashcards/Queries/GetDeckDetail.cs
+++ b/src/Kursa.Application/Features/Flashcards/Queries/GetDeckDetail.cs
@@ -1,0 +1,40 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Flashcards.Queries;
+
+public sealed record GetDeckDetailQuery(Guid DeckId) : IRequest<Result<FlashcardDeckDetailDto>>;
+
+public sealed class GetDeckDetailHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetDeckDetailQuery, Result<FlashcardDeckDetailDto>>
+{
+    public async Task<Result<FlashcardDeckDetailDto>> Handle(GetDeckDetailQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<FlashcardDeckDetailDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<FlashcardDeckDetailDto>.Failure("User not found.");
+
+        var deck = await dbContext.FlashcardDecks
+            .Include(d => d.Cards)
+            .FirstOrDefaultAsync(d => d.Id == request.DeckId && d.UserId == user.Id, cancellationToken);
+
+        if (deck is null)
+            return Result<FlashcardDeckDetailDto>.Failure("Deck not found.");
+
+        var cards = deck.Cards.Select(c => new FlashcardDto(
+            c.Id, c.Front, c.Back, c.Type,
+            c.Repetitions, c.EaseFactor, c.IntervalDays,
+            c.NextReviewAt, c.LastReviewedAt)).ToList();
+
+        return Result<FlashcardDeckDetailDto>.Success(new FlashcardDeckDetailDto(
+            deck.Id, deck.Title, deck.Description, cards));
+    }
+}

--- a/src/Kursa.Application/Features/Flashcards/Queries/GetDecks.cs
+++ b/src/Kursa.Application/Features/Flashcards/Queries/GetDecks.cs
@@ -1,0 +1,41 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Flashcards.Queries;
+
+public sealed record GetDecksQuery : IRequest<Result<IReadOnlyList<FlashcardDeckDto>>>;
+
+public sealed class GetDecksHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetDecksQuery, Result<IReadOnlyList<FlashcardDeckDto>>>
+{
+    public async Task<Result<IReadOnlyList<FlashcardDeckDto>>> Handle(GetDecksQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<FlashcardDeckDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<FlashcardDeckDto>>.Failure("User not found.");
+
+        DateTime now = DateTime.UtcNow;
+
+        List<FlashcardDeckDto> decks = await dbContext.FlashcardDecks
+            .Where(d => d.UserId == user.Id)
+            .OrderByDescending(d => d.CreatedAt)
+            .Select(d => new FlashcardDeckDto(
+                d.Id,
+                d.Title,
+                d.Description,
+                d.Cards.Count,
+                d.Cards.Count(c => c.NextReviewAt == null || c.NextReviewAt <= now),
+                d.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<FlashcardDeckDto>>.Success(decks);
+    }
+}

--- a/src/Kursa.Application/Features/Flashcards/Queries/GetDueFlashcards.cs
+++ b/src/Kursa.Application/Features/Flashcards/Queries/GetDueFlashcards.cs
@@ -1,0 +1,44 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Flashcards.Queries;
+
+public sealed record GetDueFlashcardsQuery(Guid DeckId) : IRequest<Result<IReadOnlyList<FlashcardDto>>>;
+
+public sealed class GetDueFlashcardsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetDueFlashcardsQuery, Result<IReadOnlyList<FlashcardDto>>>
+{
+    public async Task<Result<IReadOnlyList<FlashcardDto>>> Handle(GetDueFlashcardsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<FlashcardDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<FlashcardDto>>.Failure("User not found.");
+
+        bool deckExists = await dbContext.FlashcardDecks
+            .AnyAsync(d => d.Id == request.DeckId && d.UserId == user.Id, cancellationToken);
+
+        if (!deckExists)
+            return Result<IReadOnlyList<FlashcardDto>>.Failure("Deck not found.");
+
+        DateTime now = DateTime.UtcNow;
+
+        List<FlashcardDto> dueCards = await dbContext.Flashcards
+            .Where(c => c.DeckId == request.DeckId && (c.NextReviewAt == null || c.NextReviewAt <= now))
+            .OrderBy(c => c.NextReviewAt)
+            .Select(c => new FlashcardDto(
+                c.Id, c.Front, c.Back, c.Type,
+                c.Repetitions, c.EaseFactor, c.IntervalDays,
+                c.NextReviewAt, c.LastReviewedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<FlashcardDto>>.Success(dueCards);
+    }
+}

--- a/src/Kursa.Domain/Entities/Flashcard.cs
+++ b/src/Kursa.Domain/Entities/Flashcard.cs
@@ -1,0 +1,32 @@
+namespace Kursa.Domain.Entities;
+
+public class Flashcard : BaseEntity
+{
+    public Guid DeckId { get; set; }
+
+    public FlashcardDeck Deck { get; set; } = null!;
+
+    public required string Front { get; set; }
+
+    public required string Back { get; set; }
+
+    public FlashcardType Type { get; set; } = FlashcardType.Basic;
+
+    // SM-2 algorithm fields
+    public int Repetitions { get; set; }
+
+    public float EaseFactor { get; set; } = 2.5f;
+
+    public int IntervalDays { get; set; }
+
+    public DateTime? NextReviewAt { get; set; }
+
+    public DateTime? LastReviewedAt { get; set; }
+}
+
+public enum FlashcardType
+{
+    Basic,
+    Cloze,
+    Reversible,
+}

--- a/src/Kursa.Domain/Entities/FlashcardDeck.cs
+++ b/src/Kursa.Domain/Entities/FlashcardDeck.cs
@@ -1,0 +1,16 @@
+namespace Kursa.Domain.Entities;
+
+public class FlashcardDeck : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public required string Title { get; set; }
+
+    public string? Description { get; set; }
+
+    public Guid? ContentId { get; set; }
+
+    public ICollection<Flashcard> Cards { get; init; } = new List<Flashcard>();
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -46,6 +46,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/quizzes/quizzes.component').then((m) => m.QuizzesComponent),
       },
+      {
+        path: 'flashcards',
+        loadComponent: () =>
+          import('./features/flashcards/flashcards.component').then((m) => m.FlashcardsComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/flashcard.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/flashcard.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface FlashcardDeck {
+  id: string;
+  title: string;
+  description: string | null;
+  cardCount: number;
+  dueCount: number;
+  createdAt: string;
+}
+
+export interface FlashcardDeckDetail {
+  id: string;
+  title: string;
+  description: string | null;
+  cards: Flashcard[];
+}
+
+export interface Flashcard {
+  id: string;
+  front: string;
+  back: string;
+  type: 'Basic' | 'Cloze' | 'Reversible';
+  repetitions: number;
+  easeFactor: number;
+  intervalDays: number;
+  nextReviewAt: string | null;
+  lastReviewedAt: string | null;
+}
+
+export interface ReviewResult {
+  cardId: string;
+  newRepetitions: number;
+  newEaseFactor: number;
+  newIntervalDays: number;
+  nextReviewAt: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class FlashcardService {
+  private readonly http = inject(HttpClient);
+
+  getDecks(): Observable<FlashcardDeck[]> {
+    return this.http.get<FlashcardDeck[]>('/api/flashcards/decks');
+  }
+
+  getDeckDetail(deckId: string): Observable<FlashcardDeckDetail> {
+    return this.http.get<FlashcardDeckDetail>(`/api/flashcards/decks/${deckId}`);
+  }
+
+  getDueCards(deckId: string): Observable<Flashcard[]> {
+    return this.http.get<Flashcard[]>(`/api/flashcards/decks/${deckId}/due`);
+  }
+
+  generateFlashcards(contentId: string, cardCount: number, topic?: string): Observable<FlashcardDeckDetail> {
+    return this.http.post<FlashcardDeckDetail>('/api/flashcards/generate', {
+      contentId,
+      cardCount,
+      topic,
+    });
+  }
+
+  createCard(deckId: string, front: string, back: string, type = 'Basic'): Observable<Flashcard> {
+    return this.http.post<Flashcard>(`/api/flashcards/decks/${deckId}/cards`, {
+      front,
+      back,
+      type,
+    });
+  }
+
+  reviewCard(cardId: string, quality: number): Observable<ReviewResult> {
+    return this.http.post<ReviewResult>(`/api/flashcards/cards/${cardId}/review`, { quality });
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/flashcards/flashcards.component.ts
+++ b/src/Kursa.Frontend/src/app/features/flashcards/flashcards.component.ts
@@ -1,0 +1,494 @@
+import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  FlashcardDeck,
+  Flashcard,
+  FlashcardService,
+} from '../../core/services/flashcard.service';
+import { PinnedContent, PinnedContentService } from '../../core/services/pinned-content.service';
+
+type View = 'decks' | 'generate' | 'review' | 'add-card';
+
+@Component({
+  selector: 'app-flashcards',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, FormsModule],
+  template: `
+    <div class="space-y-6">
+      @switch (view()) {
+        @case ('decks') {
+          <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-bold text-foreground">Flashcards</h1>
+            <button
+              (click)="showGenerate()"
+              class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Generate Deck
+            </button>
+          </div>
+
+          @if (loading()) {
+            <div class="flex items-center justify-center py-12">
+              <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+              <span class="ml-3 text-muted-foreground">Loading decks...</span>
+            </div>
+          } @else if (decks().length === 0) {
+            <div class="rounded-lg border border-border bg-card p-8 text-center">
+              <svg class="mx-auto h-12 w-12 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" />
+              </svg>
+              <h2 class="mt-4 text-lg font-semibold text-foreground">No flashcard decks</h2>
+              <p class="mt-2 text-sm text-muted-foreground">
+                Generate flashcards from your pinned course materials for spaced repetition study.
+              </p>
+              <button
+                (click)="showGenerate()"
+                class="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Generate Your First Deck
+              </button>
+            </div>
+          } @else {
+            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              @for (deck of decks(); track deck.id) {
+                <div class="rounded-lg border border-border bg-card p-5 transition-colors hover:border-primary/50">
+                  <h3 class="font-semibold text-foreground">{{ deck.title }}</h3>
+                  @if (deck.description) {
+                    <p class="mt-1 text-xs text-muted-foreground">{{ deck.description }}</p>
+                  }
+                  <div class="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+                    <span>{{ deck.cardCount }} cards</span>
+                    @if (deck.dueCount > 0) {
+                      <span class="font-medium text-primary">{{ deck.dueCount }} due</span>
+                    } @else {
+                      <span class="text-green-500">All caught up</span>
+                    }
+                  </div>
+                  <div class="mt-4 flex gap-2">
+                    <button
+                      (click)="startReview(deck.id)"
+                      [disabled]="deck.dueCount === 0"
+                      class="flex-1 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      Review ({{ deck.dueCount }})
+                    </button>
+                    <button
+                      (click)="showAddCard(deck.id)"
+                      class="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
+                    >
+                      Add Card
+                    </button>
+                  </div>
+                  <p class="mt-2 text-xs text-muted-foreground">{{ deck.createdAt | date:'mediumDate' }}</p>
+                </div>
+              }
+            </div>
+          }
+        }
+
+        @case ('generate') {
+          <div class="flex items-center gap-3">
+            <button
+              (click)="view.set('decks')"
+              class="rounded-md p-2 text-muted-foreground hover:bg-accent"
+              aria-label="Back to decks"
+            >
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+              </svg>
+            </button>
+            <h1 class="text-2xl font-bold text-foreground">Generate Flashcards</h1>
+          </div>
+
+          @if (loadingPinned()) {
+            <div class="flex items-center justify-center py-12">
+              <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+            </div>
+          } @else if (indexedItems().length === 0) {
+            <div class="rounded-lg border border-border bg-card p-8 text-center">
+              <h2 class="text-lg font-semibold text-foreground">No indexed content</h2>
+              <p class="mt-2 text-sm text-muted-foreground">Pin and index course materials first.</p>
+            </div>
+          } @else {
+            <div class="mx-auto max-w-lg space-y-6 rounded-lg border border-border bg-card p-6">
+              <div>
+                <label for="fc-content" class="block text-sm font-medium text-foreground">Select Material</label>
+                <select
+                  id="fc-content"
+                  [(ngModel)]="selectedContentId"
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <option value="">Choose pinned content...</option>
+                  @for (item of indexedItems(); track item.contentId) {
+                    <option [value]="item.contentId">{{ item.contentTitle }}</option>
+                  }
+                </select>
+              </div>
+              <div>
+                <label for="fc-count" class="block text-sm font-medium text-foreground">Number of Cards</label>
+                <input
+                  id="fc-count"
+                  type="number"
+                  [(ngModel)]="cardCount"
+                  min="1"
+                  max="100"
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div>
+                <label for="fc-topic" class="block text-sm font-medium text-foreground">Topic (optional)</label>
+                <input
+                  id="fc-topic"
+                  type="text"
+                  [(ngModel)]="topicInput"
+                  placeholder="Focus on a specific topic..."
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              @if (error()) {
+                <div class="rounded-md border border-destructive/50 bg-destructive/10 p-3">
+                  <p class="text-sm text-destructive">{{ error() }}</p>
+                </div>
+              }
+
+              <button
+                (click)="generateDeck()"
+                [disabled]="generating() || !selectedContentId"
+                class="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                @if (generating()) {
+                  <span class="flex items-center justify-center gap-2">
+                    <span class="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent"></span>
+                    Generating...
+                  </span>
+                } @else {
+                  Generate Flashcards
+                }
+              </button>
+            </div>
+          }
+        }
+
+        @case ('review') {
+          @if (reviewCards().length > 0) {
+            <div class="mx-auto max-w-xl space-y-6">
+              <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                  <button
+                    (click)="backToDecks()"
+                    class="rounded-md p-2 text-muted-foreground hover:bg-accent"
+                    aria-label="Back to decks"
+                  >
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+                    </svg>
+                  </button>
+                  <h1 class="text-xl font-bold text-foreground">Review</h1>
+                </div>
+                <span class="text-sm text-muted-foreground">
+                  {{ currentCardIndex() + 1 }}/{{ reviewCards().length }}
+                </span>
+              </div>
+
+              <!-- Progress -->
+              <div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full bg-primary transition-all"
+                  [style.width.%]="((currentCardIndex() + 1) / reviewCards().length) * 100"
+                ></div>
+              </div>
+
+              @if (currentCard(); as card) {
+                <!-- Flashcard -->
+                <button
+                  (click)="flipped.set(!flipped())"
+                  class="w-full cursor-pointer rounded-lg border border-border bg-card p-8 text-center transition-all hover:border-primary/50 focus:outline-none focus:ring-2 focus:ring-ring"
+                  [attr.aria-label]="flipped() ? 'Showing answer, click to show question' : 'Showing question, click to reveal answer'"
+                >
+                  @if (!flipped()) {
+                    <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Question</p>
+                    <p class="mt-4 text-lg font-medium text-foreground">{{ card.front }}</p>
+                    <p class="mt-6 text-xs text-muted-foreground">Click to reveal answer</p>
+                  } @else {
+                    <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Answer</p>
+                    <p class="mt-4 text-lg font-medium text-foreground">{{ card.back }}</p>
+                  }
+                </button>
+
+                <!-- Rating buttons (only when flipped) -->
+                @if (flipped()) {
+                  <div class="space-y-2">
+                    <p class="text-center text-sm text-muted-foreground">How well did you know this?</p>
+                    <div class="grid grid-cols-4 gap-2">
+                      <button
+                        (click)="rateCard(1)"
+                        class="rounded-md border border-destructive/50 bg-destructive/10 py-2 text-xs font-medium text-destructive hover:bg-destructive/20"
+                      >
+                        Again
+                      </button>
+                      <button
+                        (click)="rateCard(3)"
+                        class="rounded-md border border-orange-500/50 bg-orange-500/10 py-2 text-xs font-medium text-orange-500 hover:bg-orange-500/20"
+                      >
+                        Hard
+                      </button>
+                      <button
+                        (click)="rateCard(4)"
+                        class="rounded-md border border-primary/50 bg-primary/10 py-2 text-xs font-medium text-primary hover:bg-primary/20"
+                      >
+                        Good
+                      </button>
+                      <button
+                        (click)="rateCard(5)"
+                        class="rounded-md border border-green-500/50 bg-green-500/10 py-2 text-xs font-medium text-green-500 hover:bg-green-500/20"
+                      >
+                        Easy
+                      </button>
+                    </div>
+                  </div>
+                }
+              }
+            </div>
+          } @else {
+            <div class="mx-auto max-w-xl text-center">
+              <div class="rounded-lg border border-border bg-card p-8">
+                <svg class="mx-auto h-12 w-12 text-green-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+                <h2 class="mt-4 text-lg font-semibold text-foreground">Review Complete!</h2>
+                <p class="mt-2 text-sm text-muted-foreground">
+                  You reviewed {{ reviewedCount() }} card{{ reviewedCount() === 1 ? '' : 's' }}. Great work!
+                </p>
+                <button
+                  (click)="backToDecks()"
+                  class="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  Back to Decks
+                </button>
+              </div>
+            </div>
+          }
+        }
+
+        @case ('add-card') {
+          <div class="flex items-center gap-3">
+            <button
+              (click)="backToDecks()"
+              class="rounded-md p-2 text-muted-foreground hover:bg-accent"
+              aria-label="Back to decks"
+            >
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+              </svg>
+            </button>
+            <h1 class="text-2xl font-bold text-foreground">Add Flashcard</h1>
+          </div>
+
+          <div class="mx-auto max-w-lg space-y-6 rounded-lg border border-border bg-card p-6">
+            <div>
+              <label for="card-front" class="block text-sm font-medium text-foreground">Front (Question)</label>
+              <textarea
+                id="card-front"
+                [(ngModel)]="newCardFront"
+                rows="3"
+                placeholder="Enter the question or prompt..."
+                class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              ></textarea>
+            </div>
+            <div>
+              <label for="card-back" class="block text-sm font-medium text-foreground">Back (Answer)</label>
+              <textarea
+                id="card-back"
+                [(ngModel)]="newCardBack"
+                rows="3"
+                placeholder="Enter the answer..."
+                class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              ></textarea>
+            </div>
+
+            @if (error()) {
+              <div class="rounded-md border border-destructive/50 bg-destructive/10 p-3">
+                <p class="text-sm text-destructive">{{ error() }}</p>
+              </div>
+            }
+
+            @if (cardAdded()) {
+              <div class="rounded-md border border-green-500/50 bg-green-500/10 p-3">
+                <p class="text-sm text-green-500">Card added successfully!</p>
+              </div>
+            }
+
+            <button
+              (click)="addCard()"
+              [disabled]="!newCardFront.trim() || !newCardBack.trim()"
+              class="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              Add Card
+            </button>
+          </div>
+        }
+      }
+    </div>
+  `,
+})
+export class FlashcardsComponent implements OnInit {
+  private readonly flashcardService = inject(FlashcardService);
+  private readonly pinnedService = inject(PinnedContentService);
+
+  readonly view = signal<View>('decks');
+  readonly loading = signal(true);
+  readonly generating = signal(false);
+  readonly error = signal<string | null>(null);
+
+  readonly decks = signal<FlashcardDeck[]>([]);
+  readonly pinnedItems = signal<PinnedContent[]>([]);
+  readonly loadingPinned = signal(false);
+
+  // Generate form
+  selectedContentId = '';
+  cardCount = 20;
+  topicInput = '';
+
+  // Review state
+  readonly reviewCards = signal<Flashcard[]>([]);
+  readonly currentCardIndex = signal(0);
+  readonly flipped = signal(false);
+  readonly reviewedCount = signal(0);
+  private currentDeckId = '';
+
+  // Add card state
+  private addCardDeckId = '';
+  newCardFront = '';
+  newCardBack = '';
+  readonly cardAdded = signal(false);
+
+  readonly indexedItems = computed(() => this.pinnedItems().filter((p) => p.isIndexed));
+
+  readonly currentCard = computed(() => {
+    const cards = this.reviewCards();
+    const index = this.currentCardIndex();
+    return cards[index] ?? null;
+  });
+
+  ngOnInit(): void {
+    this.loadDecks();
+  }
+
+  loadDecks(): void {
+    this.loading.set(true);
+    this.flashcardService.getDecks().subscribe({
+      next: (decks) => {
+        this.decks.set(decks);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to load decks.';
+        this.error.set(message);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  showGenerate(): void {
+    this.view.set('generate');
+    this.error.set(null);
+    if (this.pinnedItems().length === 0) {
+      this.loadingPinned.set(true);
+      this.pinnedService.getPinnedContents().subscribe({
+        next: (items) => {
+          this.pinnedItems.set(items);
+          this.loadingPinned.set(false);
+        },
+        error: () => this.loadingPinned.set(false),
+      });
+    }
+  }
+
+  generateDeck(): void {
+    if (!this.selectedContentId) return;
+    this.generating.set(true);
+    this.error.set(null);
+
+    const topic = this.topicInput.trim() || undefined;
+
+    this.flashcardService.generateFlashcards(this.selectedContentId, this.cardCount, topic).subscribe({
+      next: () => {
+        this.generating.set(false);
+        this.view.set('decks');
+        this.loadDecks();
+      },
+      error: (err) => {
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to generate flashcards.';
+        this.error.set(message);
+        this.generating.set(false);
+      },
+    });
+  }
+
+  startReview(deckId: string): void {
+    this.currentDeckId = deckId;
+    this.loading.set(true);
+    this.flashcardService.getDueCards(deckId).subscribe({
+      next: (cards) => {
+        this.reviewCards.set(cards);
+        this.currentCardIndex.set(0);
+        this.flipped.set(false);
+        this.reviewedCount.set(0);
+        this.view.set('review');
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  rateCard(quality: number): void {
+    const card = this.currentCard();
+    if (!card) return;
+
+    this.flashcardService.reviewCard(card.id, quality).subscribe({
+      next: () => {
+        this.reviewedCount.update((c) => c + 1);
+        const nextIndex = this.currentCardIndex() + 1;
+        if (nextIndex < this.reviewCards().length) {
+          this.currentCardIndex.set(nextIndex);
+          this.flipped.set(false);
+        } else {
+          // Review complete — clear cards to show completion screen
+          this.reviewCards.set([]);
+        }
+      },
+    });
+  }
+
+  showAddCard(deckId: string): void {
+    this.addCardDeckId = deckId;
+    this.newCardFront = '';
+    this.newCardBack = '';
+    this.cardAdded.set(false);
+    this.error.set(null);
+    this.view.set('add-card');
+  }
+
+  addCard(): void {
+    if (!this.newCardFront.trim() || !this.newCardBack.trim()) return;
+
+    this.flashcardService.createCard(this.addCardDeckId, this.newCardFront.trim(), this.newCardBack.trim()).subscribe({
+      next: () => {
+        this.cardAdded.set(true);
+        this.newCardFront = '';
+        this.newCardBack = '';
+      },
+      error: (err) => {
+        const message = typeof err.error === 'string' ? err.error : err.message ?? 'Failed to add card.';
+        this.error.set(message);
+      },
+    });
+  }
+
+  backToDecks(): void {
+    this.view.set('decks');
+    this.loadDecks();
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -65,6 +65,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Quizzes
         </a>
         <a
+          routerLink="/flashcards"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3" /></svg>
+          Flashcards
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/Migrations/20260310215922_AddFlashcardEntities.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310215922_AddFlashcardEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310215922_AddFlashcardEntities")]
+    partial class AddFlashcardEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310215922_AddFlashcardEntities.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310215922_AddFlashcardEntities.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFlashcardEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FlashcardDecks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    ContentId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FlashcardDecks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FlashcardDecks_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Flashcards",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeckId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Front = table.Column<string>(type: "text", nullable: false),
+                    Back = table.Column<string>(type: "text", nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Repetitions = table.Column<int>(type: "integer", nullable: false),
+                    EaseFactor = table.Column<float>(type: "real", nullable: false),
+                    IntervalDays = table.Column<int>(type: "integer", nullable: false),
+                    NextReviewAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastReviewedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Flashcards", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Flashcards_FlashcardDecks_DeckId",
+                        column: x => x.DeckId,
+                        principalTable: "FlashcardDecks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FlashcardDecks_UserId",
+                table: "FlashcardDecks",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Flashcards_DeckId",
+                table: "Flashcards",
+                column: "DeckId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Flashcards");
+
+            migrationBuilder.DropTable(
+                name: "FlashcardDecks");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -32,6 +32,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<QuizAnswer> QuizAnswers => Set<QuizAnswer>();
 
+    public DbSet<FlashcardDeck> FlashcardDecks => Set<FlashcardDeck>();
+
+    public DbSet<Flashcard> Flashcards => Set<Flashcard>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);


### PR DESCRIPTION
## Summary
- **Domain**: FlashcardDeck + Flashcard entities with full SM-2 spaced repetition fields
- **Backend**: CQRS with LLM-powered generation, manual card creation, SM-2 review algorithm (ease factor, interval, repetition tracking)
- **Frontend**: Deck list with due counts, generate form, flip-card review UI with Again/Hard/Good/Easy rating, manual card creation form
- **Navigation**: Sidebar updated with Flashcards link

## Test plan
- [ ] Generate flashcards from pinned indexed content
- [ ] Review due cards with flip interaction and SM-2 rating buttons
- [ ] Verify SM-2 scheduling: "Again" resets interval to 1 day, "Easy" extends interval
- [ ] Add manual flashcard to existing deck
- [ ] Verify due count updates after review session
- [ ] Visually verified via Playwright: empty state, sidebar active state

Closes #14