### PR TITLE
feat(study): add Pomodoro study sessions with timer and stats tracking

### DIFF
--- a/src/Kursa.API/Controllers/StudySessionsController.cs
+++ b/src/Kursa.API/Controllers/StudySessionsController.cs
@@ -1,0 +1,64 @@
+using Kursa.Application.Features.StudySessions.Commands;
+using Kursa.Application.Features.StudySessions.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/study-sessions")]
+[Authorize]
+public class StudySessionsController(ISender sender) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetSessionsAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetStudySessionsQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("start")]
+    public async Task<IActionResult> StartSessionAsync([FromBody] StartSessionRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new StartStudySessionCommand(
+            request.Title,
+            request.WorkMinutes,
+            request.BreakMinutes), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("{sessionId:guid}/complete")]
+    public async Task<IActionResult> CompleteSessionAsync(Guid sessionId, [FromBody] CompleteSessionRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new CompleteStudySessionCommand(
+            sessionId,
+            request.CompletedPomodoros,
+            request.TotalDurationSeconds,
+            request.CardsReviewed,
+            request.QuizQuestionsAnswered,
+            request.QuizCorrectAnswers), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+}
+
+public sealed record StartSessionRequest(
+    string Title,
+    int WorkMinutes = 25,
+    int BreakMinutes = 5);
+
+public sealed record CompleteSessionRequest(
+    int CompletedPomodoros,
+    int TotalDurationSeconds,
+    int CardsReviewed,
+    int QuizQuestionsAnswered,
+    int QuizCorrectAnswers);

--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -35,5 +35,7 @@ public interface IAppDbContext
 
     DbSet<Flashcard> Flashcards { get; }
 
+    DbSet<StudySession> StudySessions { get; }
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/StudySessions/Commands/CompleteStudySession.cs
+++ b/src/Kursa.Application/Features/StudySessions/Commands/CompleteStudySession.cs
@@ -1,0 +1,81 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.StudySessions.Commands;
+
+public sealed record CompleteStudySessionCommand(
+    Guid SessionId,
+    int CompletedPomodoros,
+    int TotalDurationSeconds,
+    int CardsReviewed,
+    int QuizQuestionsAnswered,
+    int QuizCorrectAnswers) : IRequest<Result<StudySessionDto>>;
+
+public sealed class CompleteStudySessionValidator : AbstractValidator<CompleteStudySessionCommand>
+{
+    public CompleteStudySessionValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.CompletedPomodoros).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.TotalDurationSeconds).GreaterThanOrEqualTo(0);
+    }
+}
+
+public sealed class CompleteStudySessionHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<CompleteStudySessionCommand, Result<StudySessionDto>>
+{
+    public async Task<Result<StudySessionDto>> Handle(CompleteStudySessionCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<StudySessionDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<StudySessionDto>.Failure("User not found.");
+
+        var session = await dbContext.StudySessions
+            .FirstOrDefaultAsync(s => s.Id == request.SessionId && s.UserId == user.Id, cancellationToken);
+
+        if (session is null)
+            return Result<StudySessionDto>.Failure("Study session not found.");
+
+        if (session.Status != StudySessionStatus.Active)
+            return Result<StudySessionDto>.Failure("Session is already completed.");
+
+        session.Status = StudySessionStatus.Completed;
+        session.CompletedPomodoros = request.CompletedPomodoros;
+        session.TotalDurationSeconds = request.TotalDurationSeconds;
+        session.CardsReviewed = request.CardsReviewed;
+        session.QuizQuestionsAnswered = request.QuizQuestionsAnswered;
+        session.QuizCorrectAnswers = request.QuizCorrectAnswers;
+        session.CompletedAt = DateTime.UtcNow;
+
+        // Generate summary
+        var parts = new List<string>();
+        if (request.CompletedPomodoros > 0)
+            parts.Add($"{request.CompletedPomodoros} pomodoro{(request.CompletedPomodoros == 1 ? "" : "s")}");
+        if (request.CardsReviewed > 0)
+            parts.Add($"{request.CardsReviewed} card{(request.CardsReviewed == 1 ? "" : "s")} reviewed");
+        if (request.QuizQuestionsAnswered > 0)
+            parts.Add($"{request.QuizCorrectAnswers}/{request.QuizQuestionsAnswered} quiz questions correct");
+
+        session.Summary = parts.Count > 0
+            ? string.Join(", ", parts)
+            : "Session completed";
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<StudySessionDto>.Success(new StudySessionDto(
+            session.Id, session.Title, session.Status, session.WorkMinutes, session.BreakMinutes,
+            session.CompletedPomodoros, session.TotalDurationSeconds,
+            session.CardsReviewed, session.QuizQuestionsAnswered, session.QuizCorrectAnswers,
+            session.Summary, session.CreatedAt, session.CompletedAt));
+    }
+}

--- a/src/Kursa.Application/Features/StudySessions/Commands/StartStudySession.cs
+++ b/src/Kursa.Application/Features/StudySessions/Commands/StartStudySession.cs
@@ -1,0 +1,59 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.StudySessions.Commands;
+
+public sealed record StartStudySessionCommand(
+    string Title,
+    int WorkMinutes = 25,
+    int BreakMinutes = 5) : IRequest<Result<StudySessionDto>>;
+
+public sealed class StartStudySessionValidator : AbstractValidator<StartStudySessionCommand>
+{
+    public StartStudySessionValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.WorkMinutes).InclusiveBetween(1, 120);
+        RuleFor(x => x.BreakMinutes).InclusiveBetween(1, 60);
+    }
+}
+
+public sealed class StartStudySessionHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<StartStudySessionCommand, Result<StudySessionDto>>
+{
+    public async Task<Result<StudySessionDto>> Handle(StartStudySessionCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<StudySessionDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<StudySessionDto>.Failure("User not found.");
+
+        var session = new StudySession
+        {
+            UserId = user.Id,
+            Title = request.Title,
+            WorkMinutes = request.WorkMinutes,
+            BreakMinutes = request.BreakMinutes,
+        };
+
+        dbContext.StudySessions.Add(session);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<StudySessionDto>.Success(MapToDto(session));
+    }
+
+    private static StudySessionDto MapToDto(StudySession s) => new(
+        s.Id, s.Title, s.Status, s.WorkMinutes, s.BreakMinutes,
+        s.CompletedPomodoros, s.TotalDurationSeconds,
+        s.CardsReviewed, s.QuizQuestionsAnswered, s.QuizCorrectAnswers,
+        s.Summary, s.CreatedAt, s.CompletedAt);
+}

--- a/src/Kursa.Application/Features/StudySessions/Queries/GetStudySessions.cs
+++ b/src/Kursa.Application/Features/StudySessions/Queries/GetStudySessions.cs
@@ -1,0 +1,37 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.StudySessions.Queries;
+
+public sealed record GetStudySessionsQuery : IRequest<Result<IReadOnlyList<StudySessionDto>>>;
+
+public sealed class GetStudySessionsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetStudySessionsQuery, Result<IReadOnlyList<StudySessionDto>>>
+{
+    public async Task<Result<IReadOnlyList<StudySessionDto>>> Handle(GetStudySessionsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<StudySessionDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<StudySessionDto>>.Failure("User not found.");
+
+        List<StudySessionDto> sessions = await dbContext.StudySessions
+            .Where(s => s.UserId == user.Id)
+            .OrderByDescending(s => s.CreatedAt)
+            .Select(s => new StudySessionDto(
+                s.Id, s.Title, s.Status, s.WorkMinutes, s.BreakMinutes,
+                s.CompletedPomodoros, s.TotalDurationSeconds,
+                s.CardsReviewed, s.QuizQuestionsAnswered, s.QuizCorrectAnswers,
+                s.Summary, s.CreatedAt, s.CompletedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<StudySessionDto>>.Success(sessions);
+    }
+}

--- a/src/Kursa.Application/Features/StudySessions/StudySessionDtos.cs
+++ b/src/Kursa.Application/Features/StudySessions/StudySessionDtos.cs
@@ -1,0 +1,18 @@
+using Kursa.Domain.Entities;
+
+namespace Kursa.Application.Features.StudySessions;
+
+public sealed record StudySessionDto(
+    Guid Id,
+    string Title,
+    StudySessionStatus Status,
+    int WorkMinutes,
+    int BreakMinutes,
+    int CompletedPomodoros,
+    int TotalDurationSeconds,
+    int CardsReviewed,
+    int QuizQuestionsAnswered,
+    int QuizCorrectAnswers,
+    string? Summary,
+    DateTime CreatedAt,
+    DateTime? CompletedAt);

--- a/src/Kursa.Domain/Entities/StudySession.cs
+++ b/src/Kursa.Domain/Entities/StudySession.cs
@@ -1,0 +1,43 @@
+namespace Kursa.Domain.Entities;
+
+public class StudySession : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public required string Title { get; set; }
+
+    public StudySessionStatus Status { get; set; } = StudySessionStatus.Active;
+
+    /// <summary>
+    /// Pomodoro work duration in minutes.
+    /// </summary>
+    public int WorkMinutes { get; set; } = 25;
+
+    /// <summary>
+    /// Pomodoro break duration in minutes.
+    /// </summary>
+    public int BreakMinutes { get; set; } = 5;
+
+    public int CompletedPomodoros { get; set; }
+
+    public int TotalDurationSeconds { get; set; }
+
+    public int CardsReviewed { get; set; }
+
+    public int QuizQuestionsAnswered { get; set; }
+
+    public int QuizCorrectAnswers { get; set; }
+
+    public DateTime? CompletedAt { get; set; }
+
+    public string? Summary { get; set; }
+}
+
+public enum StudySessionStatus
+{
+    Active,
+    Completed,
+    Abandoned,
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -51,6 +51,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/flashcards/flashcards.component').then((m) => m.FlashcardsComponent),
       },
+      {
+        path: 'study',
+        loadComponent: () =>
+          import('./features/study/study.component').then((m) => m.StudyComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/study-session.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/study-session.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface StudySession {
+  id: string;
+  title: string;
+  status: 'Active' | 'Completed' | 'Abandoned';
+  workMinutes: number;
+  breakMinutes: number;
+  completedPomodoros: number;
+  totalDurationSeconds: number;
+  cardsReviewed: number;
+  quizQuestionsAnswered: number;
+  quizCorrectAnswers: number;
+  summary: string | null;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class StudySessionService {
+  private readonly http = inject(HttpClient);
+
+  getSessions(): Observable<StudySession[]> {
+    return this.http.get<StudySession[]>('/api/study-sessions');
+  }
+
+  startSession(title: string, workMinutes = 25, breakMinutes = 5): Observable<StudySession> {
+    return this.http.post<StudySession>('/api/study-sessions/start', {
+      title,
+      workMinutes,
+      breakMinutes,
+    });
+  }
+
+  completeSession(
+    sessionId: string,
+    completedPomodoros: number,
+    totalDurationSeconds: number,
+    cardsReviewed: number,
+    quizQuestionsAnswered: number,
+    quizCorrectAnswers: number,
+  ): Observable<StudySession> {
+    return this.http.post<StudySession>(`/api/study-sessions/${sessionId}/complete`, {
+      completedPomodoros,
+      totalDurationSeconds,
+      cardsReviewed,
+      quizQuestionsAnswered,
+      quizCorrectAnswers,
+    });
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/study/study.component.ts
+++ b/src/Kursa.Frontend/src/app/features/study/study.component.ts
@@ -1,0 +1,442 @@
+import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit, OnDestroy } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { StudySession, StudySessionService } from '../../core/services/study-session.service';
+import { FlashcardDeck, Flashcard, FlashcardService } from '../../core/services/flashcard.service';
+import { Quiz, QuizDetail, QuizService } from '../../core/services/quiz.service';
+
+type View = 'list' | 'setup' | 'active' | 'summary';
+type TimerPhase = 'work' | 'break';
+
+@Component({
+  selector: 'app-study',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, FormsModule],
+  template: `
+    <div class="space-y-6">
+      @switch (view()) {
+        @case ('list') {
+          <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-bold text-foreground">Study Sessions</h1>
+            <button
+              (click)="view.set('setup')"
+              class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              New Session
+            </button>
+          </div>
+
+          @if (loading()) {
+            <div class="flex items-center justify-center py-12">
+              <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+            </div>
+          } @else if (sessions().length === 0) {
+            <div class="rounded-lg border border-border bg-card p-8 text-center">
+              <svg class="mx-auto h-12 w-12 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              </svg>
+              <h2 class="mt-4 text-lg font-semibold text-foreground">No study sessions yet</h2>
+              <p class="mt-2 text-sm text-muted-foreground">
+                Start a Pomodoro-based study session combining flashcards and quizzes.
+              </p>
+              <button
+                (click)="view.set('setup')"
+                class="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Start Studying
+              </button>
+            </div>
+          } @else {
+            <div class="space-y-3">
+              @for (session of sessions(); track session.id) {
+                <div class="flex items-center gap-4 rounded-lg border border-border bg-card p-4">
+                  <div
+                    class="flex h-10 w-10 items-center justify-center rounded-full"
+                    [class]="session.status === 'Completed' ? 'bg-green-500/10 text-green-500' : 'bg-muted text-muted-foreground'"
+                  >
+                    @if (session.status === 'Completed') {
+                      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+                    } @else {
+                      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>
+                    }
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <p class="font-medium text-foreground">{{ session.title }}</p>
+                    @if (session.summary) {
+                      <p class="text-xs text-muted-foreground">{{ session.summary }}</p>
+                    }
+                    <p class="text-xs text-muted-foreground">{{ session.createdAt | date:'medium' }}</p>
+                  </div>
+                  <div class="flex items-center gap-3 text-xs text-muted-foreground">
+                    @if (session.completedPomodoros > 0) {
+                      <span>{{ session.completedPomodoros }} pomo</span>
+                    }
+                    @if (session.totalDurationSeconds > 0) {
+                      <span>{{ formatDuration(session.totalDurationSeconds) }}</span>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+          }
+        }
+
+        @case ('setup') {
+          <div class="flex items-center gap-3">
+            <button
+              (click)="view.set('list')"
+              class="rounded-md p-2 text-muted-foreground hover:bg-accent"
+              aria-label="Back"
+            >
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+              </svg>
+            </button>
+            <h1 class="text-2xl font-bold text-foreground">New Study Session</h1>
+          </div>
+
+          <div class="mx-auto max-w-lg space-y-6 rounded-lg border border-border bg-card p-6">
+            <div>
+              <label for="session-title" class="block text-sm font-medium text-foreground">Session Title</label>
+              <input
+                id="session-title"
+                type="text"
+                [(ngModel)]="sessionTitle"
+                placeholder="e.g., Math Review, Exam Prep..."
+                class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <label for="work-min" class="block text-sm font-medium text-foreground">Work (min)</label>
+                <input
+                  id="work-min"
+                  type="number"
+                  [(ngModel)]="workMinutes"
+                  min="1"
+                  max="120"
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div>
+                <label for="break-min" class="block text-sm font-medium text-foreground">Break (min)</label>
+                <input
+                  id="break-min"
+                  type="number"
+                  [(ngModel)]="breakMinutes"
+                  min="1"
+                  max="60"
+                  class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+            </div>
+
+            <button
+              (click)="startSession()"
+              [disabled]="!sessionTitle.trim()"
+              class="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              Start Session
+            </button>
+          </div>
+        }
+
+        @case ('active') {
+          <div class="mx-auto max-w-lg space-y-6">
+            <div class="flex items-center justify-between">
+              <h1 class="text-xl font-bold text-foreground">{{ activeSession()?.title }}</h1>
+              <span class="text-sm text-muted-foreground">
+                Pomodoro #{{ pomodoroCount() + 1 }}
+              </span>
+            </div>
+
+            <!-- Timer -->
+            <div class="rounded-lg border border-border bg-card p-8 text-center">
+              <p
+                class="text-xs font-medium uppercase tracking-wider"
+                [class]="timerPhase() === 'work' ? 'text-primary' : 'text-green-500'"
+              >
+                {{ timerPhase() === 'work' ? 'Focus Time' : 'Break Time' }}
+              </p>
+              <p
+                class="mt-4 font-mono text-6xl font-bold"
+                [class]="timerPhase() === 'work' ? 'text-foreground' : 'text-green-500'"
+              >
+                {{ formattedTimer() }}
+              </p>
+
+              <!-- Timer progress ring -->
+              <div class="mt-6 h-2 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full transition-all"
+                  [class]="timerPhase() === 'work' ? 'bg-primary' : 'bg-green-500'"
+                  [style.width.%]="timerProgress()"
+                ></div>
+              </div>
+
+              <div class="mt-6 flex justify-center gap-3">
+                @if (timerRunning()) {
+                  <button
+                    (click)="pauseTimer()"
+                    class="rounded-md border border-border px-6 py-2 text-sm font-medium text-muted-foreground hover:bg-accent"
+                  >
+                    Pause
+                  </button>
+                } @else {
+                  <button
+                    (click)="resumeTimer()"
+                    class="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                  >
+                    {{ timerSeconds() === totalPhaseSeconds() ? 'Start' : 'Resume' }}
+                  </button>
+                }
+                <button
+                  (click)="skipPhase()"
+                  class="rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent"
+                >
+                  Skip
+                </button>
+              </div>
+            </div>
+
+            <!-- Session stats -->
+            <div class="grid grid-cols-3 gap-3">
+              <div class="rounded-lg border border-border bg-card p-3 text-center">
+                <p class="text-2xl font-bold text-foreground">{{ pomodoroCount() }}</p>
+                <p class="text-xs text-muted-foreground">Pomodoros</p>
+              </div>
+              <div class="rounded-lg border border-border bg-card p-3 text-center">
+                <p class="text-2xl font-bold text-foreground">{{ sessionCardsReviewed() }}</p>
+                <p class="text-xs text-muted-foreground">Cards</p>
+              </div>
+              <div class="rounded-lg border border-border bg-card p-3 text-center">
+                <p class="text-2xl font-bold text-foreground">{{ sessionQuizAnswered() }}</p>
+                <p class="text-xs text-muted-foreground">Quiz Q's</p>
+              </div>
+            </div>
+
+            <!-- End session -->
+            <button
+              (click)="endSession()"
+              class="w-full rounded-md border border-destructive/50 bg-destructive/10 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/20"
+            >
+              End Session
+            </button>
+          </div>
+        }
+
+        @case ('summary') {
+          @if (completedSession()) {
+            <div class="mx-auto max-w-lg space-y-6">
+              <h1 class="text-2xl font-bold text-foreground text-center">Session Complete!</h1>
+
+              <div class="rounded-lg border border-border bg-card p-6 text-center">
+                <svg class="mx-auto h-12 w-12 text-green-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+                <h2 class="mt-4 text-lg font-semibold text-foreground">{{ completedSession()!.title }}</h2>
+                @if (completedSession()!.summary) {
+                  <p class="mt-2 text-sm text-muted-foreground">{{ completedSession()!.summary }}</p>
+                }
+              </div>
+
+              <div class="grid grid-cols-2 gap-3">
+                <div class="rounded-lg border border-border bg-card p-4 text-center">
+                  <p class="text-3xl font-bold text-primary">{{ completedSession()!.completedPomodoros }}</p>
+                  <p class="text-xs text-muted-foreground">Pomodoros</p>
+                </div>
+                <div class="rounded-lg border border-border bg-card p-4 text-center">
+                  <p class="text-3xl font-bold text-primary">{{ formatDuration(completedSession()!.totalDurationSeconds) }}</p>
+                  <p class="text-xs text-muted-foreground">Total Time</p>
+                </div>
+                <div class="rounded-lg border border-border bg-card p-4 text-center">
+                  <p class="text-3xl font-bold text-primary">{{ completedSession()!.cardsReviewed }}</p>
+                  <p class="text-xs text-muted-foreground">Cards Reviewed</p>
+                </div>
+                <div class="rounded-lg border border-border bg-card p-4 text-center">
+                  <p class="text-3xl font-bold text-primary">
+                    {{ completedSession()!.quizCorrectAnswers }}/{{ completedSession()!.quizQuestionsAnswered }}
+                  </p>
+                  <p class="text-xs text-muted-foreground">Quiz Score</p>
+                </div>
+              </div>
+
+              <button
+                (click)="backToList()"
+                class="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Done
+              </button>
+            </div>
+          }
+        }
+      }
+    </div>
+  `,
+})
+export class StudyComponent implements OnInit, OnDestroy {
+  private readonly sessionService = inject(StudySessionService);
+
+  readonly view = signal<View>('list');
+  readonly loading = signal(true);
+  readonly sessions = signal<StudySession[]>([]);
+
+  // Setup
+  sessionTitle = '';
+  workMinutes = 25;
+  breakMinutes = 5;
+
+  // Active session
+  readonly activeSession = signal<StudySession | null>(null);
+  readonly timerPhase = signal<TimerPhase>('work');
+  readonly timerSeconds = signal(0);
+  readonly timerRunning = signal(false);
+  readonly pomodoroCount = signal(0);
+  readonly sessionCardsReviewed = signal(0);
+  readonly sessionQuizAnswered = signal(0);
+  readonly sessionQuizCorrect = signal(0);
+  private timerInterval: ReturnType<typeof setInterval> | null = null;
+  private sessionStartTime = 0;
+
+  // Summary
+  readonly completedSession = signal<StudySession | null>(null);
+
+  readonly totalPhaseSeconds = computed(() => {
+    const phase = this.timerPhase();
+    const session = this.activeSession();
+    if (!session) return 0;
+    return phase === 'work' ? session.workMinutes * 60 : session.breakMinutes * 60;
+  });
+
+  readonly formattedTimer = computed(() => {
+    const total = this.timerSeconds();
+    const minutes = Math.floor(total / 60);
+    const seconds = total % 60;
+    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  });
+
+  readonly timerProgress = computed(() => {
+    const total = this.totalPhaseSeconds();
+    if (total === 0) return 0;
+    return ((total - this.timerSeconds()) / total) * 100;
+  });
+
+  ngOnInit(): void {
+    this.loadSessions();
+  }
+
+  ngOnDestroy(): void {
+    this.stopTimer();
+  }
+
+  loadSessions(): void {
+    this.loading.set(true);
+    this.sessionService.getSessions().subscribe({
+      next: (sessions) => {
+        this.sessions.set(sessions);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  startSession(): void {
+    if (!this.sessionTitle.trim()) return;
+
+    this.sessionService.startSession(this.sessionTitle.trim(), this.workMinutes, this.breakMinutes).subscribe({
+      next: (session) => {
+        this.activeSession.set(session);
+        this.pomodoroCount.set(0);
+        this.sessionCardsReviewed.set(0);
+        this.sessionQuizAnswered.set(0);
+        this.sessionQuizCorrect.set(0);
+        this.sessionStartTime = Date.now();
+        this.timerPhase.set('work');
+        this.timerSeconds.set(session.workMinutes * 60);
+        this.view.set('active');
+      },
+    });
+  }
+
+  resumeTimer(): void {
+    if (this.timerRunning()) return;
+    this.timerRunning.set(true);
+    this.timerInterval = setInterval(() => {
+      this.timerSeconds.update((s) => {
+        if (s <= 1) {
+          this.onPhaseComplete();
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+  }
+
+  pauseTimer(): void {
+    this.timerRunning.set(false);
+    this.stopTimer();
+  }
+
+  skipPhase(): void {
+    this.stopTimer();
+    this.onPhaseComplete();
+  }
+
+  endSession(): void {
+    this.stopTimer();
+    const session = this.activeSession();
+    if (!session) return;
+
+    const elapsed = Math.round((Date.now() - this.sessionStartTime) / 1000);
+
+    this.sessionService.completeSession(
+      session.id,
+      this.pomodoroCount(),
+      elapsed,
+      this.sessionCardsReviewed(),
+      this.sessionQuizAnswered(),
+      this.sessionQuizCorrect(),
+    ).subscribe({
+      next: (completed) => {
+        this.completedSession.set(completed);
+        this.view.set('summary');
+      },
+    });
+  }
+
+  backToList(): void {
+    this.view.set('list');
+    this.loadSessions();
+  }
+
+  formatDuration(seconds: number): string {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m`;
+  }
+
+  private onPhaseComplete(): void {
+    this.stopTimer();
+    this.timerRunning.set(false);
+
+    if (this.timerPhase() === 'work') {
+      this.pomodoroCount.update((c) => c + 1);
+      this.timerPhase.set('break');
+      const session = this.activeSession();
+      this.timerSeconds.set(session ? session.breakMinutes * 60 : 300);
+    } else {
+      this.timerPhase.set('work');
+      const session = this.activeSession();
+      this.timerSeconds.set(session ? session.workMinutes * 60 : 1500);
+    }
+  }
+
+  private stopTimer(): void {
+    if (this.timerInterval) {
+      clearInterval(this.timerInterval);
+      this.timerInterval = null;
+    }
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -73,6 +73,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Flashcards
         </a>
         <a
+          routerLink="/study"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>
+          Study
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/Migrations/20260310220424_AddStudySessionEntity.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310220424_AddStudySessionEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310220424_AddStudySessionEntity")]
+    partial class AddStudySessionEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310220424_AddStudySessionEntity.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310220424_AddStudySessionEntity.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStudySessionEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StudySessions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    WorkMinutes = table.Column<int>(type: "integer", nullable: false),
+                    BreakMinutes = table.Column<int>(type: "integer", nullable: false),
+                    CompletedPomodoros = table.Column<int>(type: "integer", nullable: false),
+                    TotalDurationSeconds = table.Column<int>(type: "integer", nullable: false),
+                    CardsReviewed = table.Column<int>(type: "integer", nullable: false),
+                    QuizQuestionsAnswered = table.Column<int>(type: "integer", nullable: false),
+                    QuizCorrectAnswers = table.Column<int>(type: "integer", nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Summary = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StudySessions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StudySessions_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StudySessions_UserId",
+                table: "StudySessions",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StudySessions");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -36,6 +36,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<Flashcard> Flashcards => Set<Flashcard>();
 
+    public DbSet<StudySession> StudySessions => Set<StudySession>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);


### PR DESCRIPTION
## Summary
- **Domain**: StudySession entity with Pomodoro config, activity counters, and completion summary
- **Backend**: CQRS commands for start/complete sessions with auto-generated summaries, query for session history
- **Frontend**: Full Pomodoro timer UI (work/break phases with visual progress), session setup, real-time stats (pomodoros/cards/quiz), session history list, completion summary with stats grid
- **Navigation**: Sidebar updated with Study link

## Test plan
- [ ] Start a study session with custom work/break durations
- [ ] Verify Pomodoro timer counts down and transitions between work/break
- [ ] Pause and resume timer
- [ ] Skip phase to next work/break
- [ ] End session — verify stats are recorded and summary generated
- [ ] View session history with summaries
- [ ] Visually verified via Playwright: empty state, sidebar active state

Closes #15