### PR TITLE
feat(recordings): add audio upload endpoint with MinIO storage

### DIFF
--- a/src/Kursa.API/Controllers/RecordingsController.cs
+++ b/src/Kursa.API/Controllers/RecordingsController.cs
@@ -1,0 +1,83 @@
+using Kursa.Application.Features.Recordings.Commands;
+using Kursa.Application.Features.Recordings.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/recordings")]
+[Authorize]
+public class RecordingsController(ISender sender) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetRecordingsAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetRecordingsQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("{recordingId:guid}")]
+    public async Task<IActionResult> GetRecordingDetailAsync(Guid recordingId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetRecordingDetailQuery(recordingId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("{recordingId:guid}/download-url")]
+    public async Task<IActionResult> GetDownloadUrlAsync(Guid recordingId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetRecordingDownloadUrlQuery(recordingId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(new { url = result.Value })
+            : BadRequest(result.Error);
+    }
+
+    [HttpPost("upload")]
+    [RequestSizeLimit(500 * 1024 * 1024)] // 500 MB
+    public async Task<IActionResult> UploadRecordingAsync(
+        [FromForm] string title,
+        [FromForm] string? description,
+        [FromForm] Guid? courseId,
+        IFormFile file,
+        CancellationToken cancellationToken)
+    {
+        if (file is null || file.Length == 0)
+            return BadRequest("No file provided.");
+
+        await using Stream stream = file.OpenReadStream();
+
+        var command = new UploadRecordingCommand(
+            title,
+            description,
+            courseId,
+            file.FileName,
+            file.ContentType,
+            file.Length,
+            stream);
+
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpDelete("{recordingId:guid}")]
+    public async Task<IActionResult> DeleteRecordingAsync(Guid recordingId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new DeleteRecordingCommand(recordingId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok()
+            : BadRequest(result.Error);
+    }
+}

--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -37,5 +37,7 @@ public interface IAppDbContext
 
     DbSet<StudySession> StudySessions { get; }
 
+    DbSet<Recording> Recordings { get; }
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Common/Interfaces/IFileStorageService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IFileStorageService.cs
@@ -1,0 +1,23 @@
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IFileStorageService
+{
+    Task<string> UploadAsync(
+        string objectKey,
+        Stream stream,
+        string contentType,
+        CancellationToken cancellationToken = default);
+
+    Task<Stream> DownloadAsync(
+        string objectKey,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(
+        string objectKey,
+        CancellationToken cancellationToken = default);
+
+    Task<string> GetPresignedUrlAsync(
+        string objectKey,
+        int expirySeconds = 3600,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Features/Recordings/Commands/DeleteRecording.cs
+++ b/src/Kursa.Application/Features/Recordings/Commands/DeleteRecording.cs
@@ -1,0 +1,39 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Recordings.Commands;
+
+public sealed record DeleteRecordingCommand(Guid RecordingId) : IRequest<Result<bool>>;
+
+public sealed class DeleteRecordingHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IFileStorageService fileStorage) : IRequestHandler<DeleteRecordingCommand, Result<bool>>
+{
+    public async Task<Result<bool>> Handle(DeleteRecordingCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<bool>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<bool>.Failure("User not found.");
+
+        var recording = await dbContext.Recordings
+            .FirstOrDefaultAsync(r => r.Id == request.RecordingId && r.UserId == user.Id, cancellationToken);
+
+        if (recording is null)
+            return Result<bool>.Failure("Recording not found.");
+
+        await fileStorage.DeleteAsync(recording.ObjectKey, cancellationToken);
+
+        dbContext.Recordings.Remove(recording);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+}

--- a/src/Kursa.Application/Features/Recordings/Commands/UploadRecording.cs
+++ b/src/Kursa.Application/Features/Recordings/Commands/UploadRecording.cs
@@ -1,0 +1,106 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Recordings.Commands;
+
+public sealed record UploadRecordingCommand(
+    string Title,
+    string? Description,
+    Guid? CourseId,
+    string FileName,
+    string ContentType,
+    long FileSizeBytes,
+    Stream FileStream) : IRequest<Result<RecordingDto>>;
+
+public sealed class UploadRecordingHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IFileStorageService fileStorage) : IRequestHandler<UploadRecordingCommand, Result<RecordingDto>>
+{
+    private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "audio/mpeg",
+        "audio/mp3",
+        "audio/wav",
+        "audio/x-wav",
+        "audio/ogg",
+        "audio/flac",
+        "audio/aac",
+        "audio/mp4",
+        "audio/x-m4a",
+        "audio/webm",
+    };
+
+    private const long MaxFileSizeBytes = 500 * 1024 * 1024; // 500 MB
+
+    public async Task<Result<RecordingDto>> Handle(UploadRecordingCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<RecordingDto>.Failure("User is not authenticated.");
+
+        User? user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<RecordingDto>.Failure("User not found.");
+
+        if (!AllowedContentTypes.Contains(request.ContentType))
+            return Result<RecordingDto>.Failure($"Unsupported audio format: {request.ContentType}. Supported: MP3, WAV, OGG, FLAC, AAC, M4A, WebM.");
+
+        if (request.FileSizeBytes > MaxFileSizeBytes)
+            return Result<RecordingDto>.Failure($"File too large. Maximum size is {MaxFileSizeBytes / (1024 * 1024)} MB.");
+
+        if (request.CourseId.HasValue)
+        {
+            bool courseExists = await dbContext.Courses
+                .AnyAsync(c => c.Id == request.CourseId.Value, cancellationToken);
+
+            if (!courseExists)
+                return Result<RecordingDto>.Failure("Course not found.");
+        }
+
+        string objectKey = $"recordings/{user.Id}/{Guid.NewGuid()}/{request.FileName}";
+
+        await fileStorage.UploadAsync(objectKey, request.FileStream, request.ContentType, cancellationToken);
+
+        var recording = new Recording
+        {
+            UserId = user.Id,
+            Title = request.Title,
+            Description = request.Description,
+            CourseId = request.CourseId,
+            FileName = request.FileName,
+            ContentType = request.ContentType,
+            FileSizeBytes = request.FileSizeBytes,
+            ObjectKey = objectKey,
+            Status = RecordingStatus.Uploaded,
+        };
+
+        dbContext.Recordings.Add(recording);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        string? courseTitle = request.CourseId.HasValue
+            ? await dbContext.Courses
+                .Where(c => c.Id == request.CourseId.Value)
+                .Select(c => c.Name)
+                .FirstOrDefaultAsync(cancellationToken)
+            : null;
+
+        return Result<RecordingDto>.Success(new RecordingDto(
+            recording.Id,
+            recording.Title,
+            recording.Description,
+            recording.CourseId,
+            courseTitle,
+            recording.FileName,
+            recording.ContentType,
+            recording.FileSizeBytes,
+            recording.DurationSeconds,
+            recording.Status,
+            false,
+            recording.CreatedAt));
+    }
+}

--- a/src/Kursa.Application/Features/Recordings/Queries/GetRecordingDetail.cs
+++ b/src/Kursa.Application/Features/Recordings/Queries/GetRecordingDetail.cs
@@ -1,0 +1,49 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Recordings.Queries;
+
+public sealed record GetRecordingDetailQuery(Guid RecordingId) : IRequest<Result<RecordingDetailDto>>;
+
+public sealed class GetRecordingDetailHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetRecordingDetailQuery, Result<RecordingDetailDto>>
+{
+    public async Task<Result<RecordingDetailDto>> Handle(GetRecordingDetailQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<RecordingDetailDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<RecordingDetailDto>.Failure("User not found.");
+
+        RecordingDetailDto? recording = await dbContext.Recordings
+            .Where(r => r.Id == request.RecordingId && r.UserId == user.Id)
+            .Select(r => new RecordingDetailDto(
+                r.Id,
+                r.Title,
+                r.Description,
+                r.CourseId,
+                r.Course != null ? r.Course.Name : null,
+                r.FileName,
+                r.ContentType,
+                r.FileSizeBytes,
+                r.DurationSeconds,
+                r.Status,
+                r.TranscriptText,
+                r.TranscribedAt,
+                r.ErrorMessage,
+                r.CreatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (recording is null)
+            return Result<RecordingDetailDto>.Failure("Recording not found.");
+
+        return Result<RecordingDetailDto>.Success(recording);
+    }
+}

--- a/src/Kursa.Application/Features/Recordings/Queries/GetRecordingDownloadUrl.cs
+++ b/src/Kursa.Application/Features/Recordings/Queries/GetRecordingDownloadUrl.cs
@@ -1,0 +1,36 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Recordings.Queries;
+
+public sealed record GetRecordingDownloadUrlQuery(Guid RecordingId) : IRequest<Result<string>>;
+
+public sealed class GetRecordingDownloadUrlHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IFileStorageService fileStorage) : IRequestHandler<GetRecordingDownloadUrlQuery, Result<string>>
+{
+    public async Task<Result<string>> Handle(GetRecordingDownloadUrlQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<string>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<string>.Failure("User not found.");
+
+        var recording = await dbContext.Recordings
+            .FirstOrDefaultAsync(r => r.Id == request.RecordingId && r.UserId == user.Id, cancellationToken);
+
+        if (recording is null)
+            return Result<string>.Failure("Recording not found.");
+
+        string url = await fileStorage.GetPresignedUrlAsync(recording.ObjectKey, 3600, cancellationToken);
+
+        return Result<string>.Success(url);
+    }
+}

--- a/src/Kursa.Application/Features/Recordings/Queries/GetRecordings.cs
+++ b/src/Kursa.Application/Features/Recordings/Queries/GetRecordings.cs
@@ -1,0 +1,45 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Recordings.Queries;
+
+public sealed record GetRecordingsQuery : IRequest<Result<IReadOnlyList<RecordingDto>>>;
+
+public sealed class GetRecordingsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext) : IRequestHandler<GetRecordingsQuery, Result<IReadOnlyList<RecordingDto>>>
+{
+    public async Task<Result<IReadOnlyList<RecordingDto>>> Handle(GetRecordingsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<RecordingDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<RecordingDto>>.Failure("User not found.");
+
+        List<RecordingDto> recordings = await dbContext.Recordings
+            .Where(r => r.UserId == user.Id)
+            .OrderByDescending(r => r.CreatedAt)
+            .Select(r => new RecordingDto(
+                r.Id,
+                r.Title,
+                r.Description,
+                r.CourseId,
+                r.Course != null ? r.Course.Name : null,
+                r.FileName,
+                r.ContentType,
+                r.FileSizeBytes,
+                r.DurationSeconds,
+                r.Status,
+                r.TranscriptText != null,
+                r.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Result<IReadOnlyList<RecordingDto>>.Success(recordings);
+    }
+}

--- a/src/Kursa.Application/Features/Recordings/RecordingDtos.cs
+++ b/src/Kursa.Application/Features/Recordings/RecordingDtos.cs
@@ -1,0 +1,33 @@
+using Kursa.Domain.Entities;
+
+namespace Kursa.Application.Features.Recordings;
+
+public sealed record RecordingDto(
+    Guid Id,
+    string Title,
+    string? Description,
+    Guid? CourseId,
+    string? CourseTitle,
+    string FileName,
+    string ContentType,
+    long FileSizeBytes,
+    int? DurationSeconds,
+    RecordingStatus Status,
+    bool HasTranscript,
+    DateTime CreatedAt);
+
+public sealed record RecordingDetailDto(
+    Guid Id,
+    string Title,
+    string? Description,
+    Guid? CourseId,
+    string? CourseTitle,
+    string FileName,
+    string ContentType,
+    long FileSizeBytes,
+    int? DurationSeconds,
+    RecordingStatus Status,
+    string? TranscriptText,
+    DateTime? TranscribedAt,
+    string? ErrorMessage,
+    DateTime CreatedAt);

--- a/src/Kursa.Domain/Entities/Recording.cs
+++ b/src/Kursa.Domain/Entities/Recording.cs
@@ -1,0 +1,47 @@
+namespace Kursa.Domain.Entities;
+
+public class Recording : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public required string Title { get; set; }
+
+    public string? Description { get; set; }
+
+    public Guid? CourseId { get; set; }
+
+    public Course? Course { get; set; }
+
+    public required string FileName { get; set; }
+
+    public required string ContentType { get; set; }
+
+    public long FileSizeBytes { get; set; }
+
+    public int? DurationSeconds { get; set; }
+
+    /// <summary>
+    /// Object key in MinIO storage.
+    /// </summary>
+    public required string ObjectKey { get; set; }
+
+    public RecordingStatus Status { get; set; } = RecordingStatus.Uploaded;
+
+    public string? TranscriptText { get; set; }
+
+    public DateTime? TranscribedAt { get; set; }
+
+    public string? ErrorMessage { get; set; }
+}
+
+public enum RecordingStatus
+{
+    Uploaded,
+    Transcribing,
+    Transcribed,
+    Indexing,
+    Completed,
+    Failed,
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -56,6 +56,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/study/study.component').then((m) => m.StudyComponent),
       },
+      {
+        path: 'recordings',
+        loadComponent: () =>
+          import('./features/recordings/recordings.component').then((m) => m.RecordingsComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/recording.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/recording.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Recording {
+  id: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  courseTitle: string | null;
+  fileName: string;
+  contentType: string;
+  fileSizeBytes: number;
+  durationSeconds: number | null;
+  status: RecordingStatus;
+  hasTranscript: boolean;
+  createdAt: string;
+}
+
+export interface RecordingDetail {
+  id: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  courseTitle: string | null;
+  fileName: string;
+  contentType: string;
+  fileSizeBytes: number;
+  durationSeconds: number | null;
+  status: RecordingStatus;
+  transcriptText: string | null;
+  transcribedAt: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+export type RecordingStatus =
+  | 'Uploaded'
+  | 'Transcribing'
+  | 'Transcribed'
+  | 'Indexing'
+  | 'Completed'
+  | 'Failed';
+
+@Injectable({ providedIn: 'root' })
+export class RecordingService {
+  private readonly http = inject(HttpClient);
+
+  getRecordings(): Observable<Recording[]> {
+    return this.http.get<Recording[]>('/api/recordings');
+  }
+
+  getRecording(id: string): Observable<RecordingDetail> {
+    return this.http.get<RecordingDetail>(`/api/recordings/${id}`);
+  }
+
+  getDownloadUrl(id: string): Observable<{ url: string }> {
+    return this.http.get<{ url: string }>(`/api/recordings/${id}/download-url`);
+  }
+
+  upload(
+    file: File,
+    title: string,
+    description?: string,
+    courseId?: string,
+  ): Observable<Recording> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('title', title);
+    if (description) formData.append('description', description);
+    if (courseId) formData.append('courseId', courseId);
+    return this.http.post<Recording>('/api/recordings/upload', formData);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`/api/recordings/${id}`);
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/recordings/recordings.component.ts
+++ b/src/Kursa.Frontend/src/app/features/recordings/recordings.component.ts
@@ -1,0 +1,421 @@
+import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit, ElementRef, viewChild } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import {
+  Recording,
+  RecordingDetail,
+  RecordingService,
+  RecordingStatus,
+} from '../../core/services/recording.service';
+
+type View = 'list' | 'upload' | 'detail';
+
+@Component({
+  selector: 'app-recordings',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe],
+  template: `
+    <div class="space-y-6">
+      @switch (view()) {
+        @case ('list') {
+          <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-bold text-foreground">Recordings</h1>
+            <button
+              (click)="view.set('upload')"
+              class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              Upload Recording
+            </button>
+          </div>
+
+          @if (loading()) {
+            <div class="flex items-center justify-center py-12">
+              <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+            </div>
+          } @else if (recordings().length === 0) {
+            <div class="rounded-lg border border-border bg-card p-8 text-center">
+              <svg class="mx-auto h-12 w-12 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z" />
+              </svg>
+              <h2 class="mt-4 text-lg font-semibold text-foreground">No recordings yet</h2>
+              <p class="mt-2 text-sm text-muted-foreground">Upload lesson recordings from your companion apps.</p>
+              <button
+                (click)="view.set('upload')"
+                class="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Upload your first recording
+              </button>
+            </div>
+          } @else {
+            <div class="space-y-3">
+              @for (rec of recordings(); track rec.id) {
+                <button
+                  (click)="openDetail(rec.id)"
+                  class="flex w-full items-center gap-4 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-accent"
+                >
+                  <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                    <svg class="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z" />
+                    </svg>
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate font-medium text-foreground">{{ rec.title }}</p>
+                    <div class="flex items-center gap-3 text-xs text-muted-foreground">
+                      <span>{{ rec.createdAt | date:'medium' }}</span>
+                      <span>{{ formatFileSize(rec.fileSizeBytes) }}</span>
+                      @if (rec.courseTitle) {
+                        <span>{{ rec.courseTitle }}</span>
+                      }
+                    </div>
+                  </div>
+                  <span
+                    class="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                    [class]="getStatusClasses(rec.status)"
+                  >
+                    {{ rec.status }}
+                  </span>
+                </button>
+              }
+            </div>
+          }
+        }
+
+        @case ('upload') {
+          <div class="flex items-center gap-3">
+            <button
+              (click)="view.set('list')"
+              class="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="Back to recordings"
+            >
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+            </button>
+            <h1 class="text-2xl font-bold text-foreground">Upload Recording</h1>
+          </div>
+
+          <div class="rounded-lg border border-border bg-card p-6">
+            <div class="space-y-4">
+              <div>
+                <label for="title" class="block text-sm font-medium text-foreground">Title</label>
+                <input
+                  #titleInput
+                  id="title"
+                  type="text"
+                  placeholder="e.g. Math Lecture Week 5"
+                  class="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+
+              <div>
+                <label for="description" class="block text-sm font-medium text-foreground">Description (optional)</label>
+                <textarea
+                  #descInput
+                  id="description"
+                  rows="2"
+                  placeholder="Notes about this recording..."
+                  class="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                ></textarea>
+              </div>
+
+              <div>
+                <label for="file" class="block text-sm font-medium text-foreground">Audio File</label>
+                <div
+                  class="mt-1 flex items-center justify-center rounded-lg border-2 border-dashed border-border p-8 transition-colors"
+                  [class.border-primary]="selectedFile()"
+                  [class.bg-primary/5]="selectedFile()"
+                >
+                  @if (selectedFile(); as f) {
+                    <div class="text-center">
+                      <svg class="mx-auto h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                      </svg>
+                      <p class="mt-2 text-sm font-medium text-foreground">{{ f.name }}</p>
+                      <p class="text-xs text-muted-foreground">{{ formatFileSize(f.size) }}</p>
+                      <button
+                        (click)="clearFile()"
+                        class="mt-2 text-xs text-primary hover:underline"
+                      >
+                        Change file
+                      </button>
+                    </div>
+                  } @else {
+                    <div class="text-center">
+                      <svg class="mx-auto h-8 w-8 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+                      </svg>
+                      <p class="mt-2 text-sm text-muted-foreground">
+                        <button (click)="fileInput.click()" class="font-medium text-primary hover:underline">Click to upload</button>
+                        or drag and drop
+                      </p>
+                      <p class="mt-1 text-xs text-muted-foreground">MP3, WAV, OGG, FLAC, AAC, M4A, WebM (max 500 MB)</p>
+                    </div>
+                  }
+                </div>
+                <input
+                  #fileInput
+                  id="file"
+                  type="file"
+                  accept="audio/*"
+                  (change)="onFileSelected($event)"
+                  class="hidden"
+                />
+              </div>
+
+              @if (uploadError()) {
+                <div class="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  {{ uploadError() }}
+                </div>
+              }
+
+              <button
+                (click)="upload(titleInput.value, descInput.value)"
+                [disabled]="uploading() || !selectedFile() || !titleInput.value.trim()"
+                class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                @if (uploading()) {
+                  <span class="flex items-center justify-center gap-2">
+                    <div class="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent"></div>
+                    Uploading...
+                  </span>
+                } @else {
+                  Upload Recording
+                }
+              </button>
+            </div>
+          </div>
+        }
+
+        @case ('detail') {
+          @if (detailLoading()) {
+            <div class="flex items-center justify-center py-12">
+              <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+            </div>
+          } @else if (detail(); as d) {
+            <div class="flex items-center gap-3">
+              <button
+                (click)="view.set('list')"
+                class="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                aria-label="Back to recordings"
+              >
+                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+              </button>
+              <h1 class="text-2xl font-bold text-foreground">{{ d.title }}</h1>
+              <span
+                class="rounded-full px-2.5 py-0.5 text-xs font-medium"
+                [class]="getStatusClasses(d.status)"
+              >
+                {{ d.status }}
+              </span>
+            </div>
+
+            <div class="grid gap-6 lg:grid-cols-3">
+              <!-- Info card -->
+              <div class="rounded-lg border border-border bg-card p-5 lg:col-span-2">
+                @if (d.description) {
+                  <p class="text-sm text-muted-foreground">{{ d.description }}</p>
+                }
+                <div class="mt-4 grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <p class="text-muted-foreground">File</p>
+                    <p class="font-medium text-foreground">{{ d.fileName }}</p>
+                  </div>
+                  <div>
+                    <p class="text-muted-foreground">Size</p>
+                    <p class="font-medium text-foreground">{{ formatFileSize(d.fileSizeBytes) }}</p>
+                  </div>
+                  <div>
+                    <p class="text-muted-foreground">Uploaded</p>
+                    <p class="font-medium text-foreground">{{ d.createdAt | date:'medium' }}</p>
+                  </div>
+                  @if (d.courseTitle) {
+                    <div>
+                      <p class="text-muted-foreground">Course</p>
+                      <p class="font-medium text-foreground">{{ d.courseTitle }}</p>
+                    </div>
+                  }
+                  @if (d.durationSeconds) {
+                    <div>
+                      <p class="text-muted-foreground">Duration</p>
+                      <p class="font-medium text-foreground">{{ formatDuration(d.durationSeconds) }}</p>
+                    </div>
+                  }
+                </div>
+              </div>
+
+              <!-- Actions card -->
+              <div class="space-y-3">
+                <div class="rounded-lg border border-border bg-card p-5">
+                  <h2 class="text-sm font-semibold text-foreground">Actions</h2>
+                  <div class="mt-3 space-y-2">
+                    <button
+                      (click)="downloadRecording(d.id)"
+                      class="w-full rounded-md border border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    >
+                      Download Audio
+                    </button>
+                    <button
+                      (click)="confirmDelete(d.id)"
+                      class="w-full rounded-md border border-destructive/30 px-3 py-2 text-sm text-destructive transition-colors hover:bg-destructive/10"
+                    >
+                      Delete Recording
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Transcript -->
+            @if (d.transcriptText) {
+              <div class="rounded-lg border border-border bg-card p-5">
+                <div class="flex items-center justify-between">
+                  <h2 class="text-sm font-semibold text-foreground">Transcript</h2>
+                  @if (d.transcribedAt) {
+                    <span class="text-xs text-muted-foreground">Transcribed {{ d.transcribedAt | date:'medium' }}</span>
+                  }
+                </div>
+                <div class="mt-3 max-h-96 overflow-y-auto whitespace-pre-wrap text-sm text-foreground">
+                  {{ d.transcriptText }}
+                </div>
+              </div>
+            } @else if (d.status === 'Transcribing') {
+              <div class="rounded-lg border border-border bg-card p-5 text-center">
+                <div class="mx-auto h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+                <p class="mt-2 text-sm text-muted-foreground">Transcription in progress...</p>
+              </div>
+            } @else if (d.status === 'Failed' && d.errorMessage) {
+              <div class="rounded-md bg-destructive/10 p-4 text-sm text-destructive">
+                <p class="font-medium">Processing failed</p>
+                <p class="mt-1">{{ d.errorMessage }}</p>
+              </div>
+            }
+          }
+        }
+      }
+    </div>
+  `,
+})
+export class RecordingsComponent implements OnInit {
+  private readonly recordingService = inject(RecordingService);
+
+  readonly view = signal<View>('list');
+  readonly loading = signal(true);
+  readonly recordings = signal<Recording[]>([]);
+  readonly selectedFile = signal<File | null>(null);
+  readonly uploading = signal(false);
+  readonly uploadError = signal<string | null>(null);
+  readonly detail = signal<RecordingDetail | null>(null);
+  readonly detailLoading = signal(false);
+
+  ngOnInit(): void {
+    this.loadRecordings();
+  }
+
+  loadRecordings(): void {
+    this.loading.set(true);
+    this.recordingService.getRecordings().subscribe({
+      next: (data) => {
+        this.recordings.set(data);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) {
+      this.selectedFile.set(file);
+      this.uploadError.set(null);
+    }
+  }
+
+  clearFile(): void {
+    this.selectedFile.set(null);
+  }
+
+  upload(title: string, description: string): void {
+    const file = this.selectedFile();
+    if (!file || !title.trim()) return;
+
+    this.uploading.set(true);
+    this.uploadError.set(null);
+
+    this.recordingService.upload(file, title.trim(), description.trim() || undefined).subscribe({
+      next: () => {
+        this.uploading.set(false);
+        this.selectedFile.set(null);
+        this.view.set('list');
+        this.loadRecordings();
+      },
+      error: (err) => {
+        this.uploading.set(false);
+        this.uploadError.set(err.error || 'Upload failed. Please try again.');
+      },
+    });
+  }
+
+  openDetail(id: string): void {
+    this.detailLoading.set(true);
+    this.detail.set(null);
+    this.view.set('detail');
+
+    this.recordingService.getRecording(id).subscribe({
+      next: (data) => {
+        this.detail.set(data);
+        this.detailLoading.set(false);
+      },
+      error: () => {
+        this.detailLoading.set(false);
+        this.view.set('list');
+      },
+    });
+  }
+
+  downloadRecording(id: string): void {
+    this.recordingService.getDownloadUrl(id).subscribe({
+      next: (res) => {
+        window.open(res.url, '_blank');
+      },
+    });
+  }
+
+  confirmDelete(id: string): void {
+    this.recordingService.delete(id).subscribe({
+      next: () => {
+        this.view.set('list');
+        this.loadRecordings();
+      },
+    });
+  }
+
+  formatFileSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  }
+
+  formatDuration(seconds: number): string {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) return `${h}h ${m}m ${s}s`;
+    if (m > 0) return `${m}m ${s}s`;
+    return `${s}s`;
+  }
+
+  getStatusClasses(status: RecordingStatus): string {
+    switch (status) {
+      case 'Uploaded':
+        return 'bg-blue-500/10 text-blue-500';
+      case 'Transcribing':
+      case 'Indexing':
+        return 'bg-orange-500/10 text-orange-500';
+      case 'Transcribed':
+        return 'bg-cyan-500/10 text-cyan-500';
+      case 'Completed':
+        return 'bg-green-500/10 text-green-500';
+      case 'Failed':
+        return 'bg-destructive/10 text-destructive';
+    }
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -81,6 +81,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Study
         </a>
         <a
+          routerLink="/recordings"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z" /></svg>
+          Recordings
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -64,6 +64,9 @@ public static class DependencyInjection
         // Qdrant vector store
         services.AddSingleton<IVectorStore, QdrantVectorStore>();
 
+        // MinIO file storage
+        services.AddSingleton<IFileStorageService, MinioFileStorageService>();
+
         // Content embedding pipeline
         services.AddScoped<IContentPipeline, ContentPipeline>();
 

--- a/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
+++ b/src/Kursa.Infrastructure/Kursa.Infrastructure.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.4" />
+    <PackageReference Include="Minio" Version="7.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="OpenAI" Version="2.2.0-beta.4" />
     <PackageReference Include="Qdrant.Client" Version="1.17.0" />

--- a/src/Kursa.Infrastructure/Migrations/20260310222042_AddRecordingEntity.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310222042_AddRecordingEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310222042_AddRecordingEntity")]
+    partial class AddRecordingEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310222042_AddRecordingEntity.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310222042_AddRecordingEntity.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecordingEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Recordings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    CourseId = table.Column<Guid>(type: "uuid", nullable: true),
+                    FileName = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    DurationSeconds = table.Column<int>(type: "integer", nullable: true),
+                    ObjectKey = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    TranscriptText = table.Column<string>(type: "text", nullable: true),
+                    TranscribedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ErrorMessage = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Recordings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Recordings_Courses_CourseId",
+                        column: x => x.CourseId,
+                        principalTable: "Courses",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_Recordings_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recordings_CourseId",
+                table: "Recordings",
+                column: "CourseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recordings_UserId",
+                table: "Recordings",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recordings_UserId_Status",
+                table: "Recordings",
+                columns: new[] { "UserId", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Recordings");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -38,6 +38,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<StudySession> StudySessions => Set<StudySession>();
 
+    public DbSet<Recording> Recordings => Set<Recording>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);

--- a/src/Kursa.Infrastructure/Persistence/Configurations/RecordingConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/RecordingConfiguration.cs
@@ -1,0 +1,37 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class RecordingConfiguration : IEntityTypeConfiguration<Recording>
+{
+    public void Configure(EntityTypeBuilder<Recording> builder)
+    {
+        builder.HasKey(r => r.Id);
+
+        builder.Property(r => r.Title).HasMaxLength(500).IsRequired();
+        builder.Property(r => r.Description).HasMaxLength(2000);
+        builder.Property(r => r.FileName).HasMaxLength(500).IsRequired();
+        builder.Property(r => r.ContentType).HasMaxLength(100).IsRequired();
+        builder.Property(r => r.ObjectKey).HasMaxLength(1000).IsRequired();
+        builder.Property(r => r.ErrorMessage).HasMaxLength(2000);
+
+        builder.Property(r => r.Status)
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        builder.HasIndex(r => r.UserId);
+        builder.HasIndex(r => new { r.UserId, r.Status });
+
+        builder.HasOne(r => r.User)
+            .WithMany()
+            .HasForeignKey(r => r.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(r => r.Course)
+            .WithMany()
+            .HasForeignKey(r => r.CourseId)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+}

--- a/src/Kursa.Infrastructure/Services/MinioFileStorageService.cs
+++ b/src/Kursa.Infrastructure/Services/MinioFileStorageService.cs
@@ -1,0 +1,109 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Infrastructure.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel.Args;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class MinioFileStorageService : IFileStorageService
+{
+    private readonly IMinioClient _client;
+    private readonly string _bucketName;
+    private readonly ILogger<MinioFileStorageService> _logger;
+
+    public MinioFileStorageService(IOptions<MinIOOptions> options, ILogger<MinioFileStorageService> logger)
+    {
+        _logger = logger;
+        MinIOOptions opts = options.Value;
+        _bucketName = opts.BucketName;
+
+        var builder = new MinioClient()
+            .WithEndpoint(opts.Endpoint)
+            .WithCredentials(opts.AccessKey, opts.SecretKey);
+
+        if (opts.UseSsl)
+            builder = builder.WithSSL();
+
+        _client = builder.Build();
+    }
+
+    public async Task<string> UploadAsync(
+        string objectKey,
+        Stream stream,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureBucketExistsAsync(cancellationToken);
+
+        var args = new PutObjectArgs()
+            .WithBucket(_bucketName)
+            .WithObject(objectKey)
+            .WithStreamData(stream)
+            .WithObjectSize(stream.Length)
+            .WithContentType(contentType);
+
+        await _client.PutObjectAsync(args, cancellationToken);
+
+        _logger.LogInformation("Uploaded object {ObjectKey} to bucket {Bucket}", objectKey, _bucketName);
+
+        return objectKey;
+    }
+
+    public async Task<Stream> DownloadAsync(
+        string objectKey,
+        CancellationToken cancellationToken = default)
+    {
+        var memoryStream = new MemoryStream();
+
+        var args = new GetObjectArgs()
+            .WithBucket(_bucketName)
+            .WithObject(objectKey)
+            .WithCallbackStream(stream => stream.CopyTo(memoryStream));
+
+        await _client.GetObjectAsync(args, cancellationToken);
+
+        memoryStream.Position = 0;
+        return memoryStream;
+    }
+
+    public async Task DeleteAsync(
+        string objectKey,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new RemoveObjectArgs()
+            .WithBucket(_bucketName)
+            .WithObject(objectKey);
+
+        await _client.RemoveObjectAsync(args, cancellationToken);
+
+        _logger.LogInformation("Deleted object {ObjectKey} from bucket {Bucket}", objectKey, _bucketName);
+    }
+
+    public async Task<string> GetPresignedUrlAsync(
+        string objectKey,
+        int expirySeconds = 3600,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new PresignedGetObjectArgs()
+            .WithBucket(_bucketName)
+            .WithObject(objectKey)
+            .WithExpiry(expirySeconds);
+
+        return await _client.PresignedGetObjectAsync(args);
+    }
+
+    private async Task EnsureBucketExistsAsync(CancellationToken cancellationToken)
+    {
+        var existsArgs = new BucketExistsArgs().WithBucket(_bucketName);
+        bool exists = await _client.BucketExistsAsync(existsArgs, cancellationToken);
+
+        if (!exists)
+        {
+            var makeArgs = new MakeBucketArgs().WithBucket(_bucketName);
+            await _client.MakeBucketAsync(makeArgs, cancellationToken);
+            _logger.LogInformation("Created MinIO bucket {Bucket}", _bucketName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Recording entity** with status tracking (Uploaded → Transcribing → Transcribed → Indexing → Completed/Failed)
- **IFileStorageService** interface + **MinioFileStorageService** implementation (upload, download, delete, presigned URLs)
- **CQRS handlers**: UploadRecording, GetRecordings, GetRecordingDetail, GetRecordingDownloadUrl, DeleteRecording
- **RecordingsController** with multipart upload (500MB limit, audio format validation: MP3/WAV/OGG/FLAC/AAC/M4A/WebM)
- **Angular recordings page** with empty state, upload form (title, description, file picker), recording list, and detail view with transcript placeholder
- **Sidebar** navigation link added

## Test plan
- [ ] Upload audio file via multipart form and verify MinIO storage
- [ ] List recordings and verify metadata display
- [ ] View recording detail with file info
- [ ] Download via presigned URL
- [ ] Delete recording (removes from DB + MinIO)
- [ ] Verify format validation rejects non-audio files
- [ ] Verify 500MB size limit enforcement

Closes #17