### PR TITLE
feat(recordings): integrate Whisper transcription microservice

### DIFF
--- a/src/Kursa.API/Controllers/RecordingsController.cs
+++ b/src/Kursa.API/Controllers/RecordingsController.cs
@@ -71,6 +71,16 @@ public class RecordingsController(ISender sender) : ControllerBase
             : BadRequest(result.Error);
     }
 
+    [HttpPost("{recordingId:guid}/transcribe")]
+    public async Task<IActionResult> TranscribeRecordingAsync(Guid recordingId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new TranscribeRecordingCommand(recordingId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok()
+            : BadRequest(result.Error);
+    }
+
     [HttpDelete("{recordingId:guid}")]
     public async Task<IActionResult> DeleteRecordingAsync(Guid recordingId, CancellationToken cancellationToken)
     {

--- a/src/Kursa.Application/Common/Interfaces/ITranscriptionQueue.cs
+++ b/src/Kursa.Application/Common/Interfaces/ITranscriptionQueue.cs
@@ -1,0 +1,6 @@
+namespace Kursa.Application.Common.Interfaces;
+
+public interface ITranscriptionQueue
+{
+    ValueTask EnqueueAsync(Guid recordingId, CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Common/Interfaces/ITranscriptionService.cs
+++ b/src/Kursa.Application/Common/Interfaces/ITranscriptionService.cs
@@ -1,0 +1,15 @@
+namespace Kursa.Application.Common.Interfaces;
+
+public interface ITranscriptionService
+{
+    Task<TranscriptionResult> TranscribeAsync(
+        Stream audioStream,
+        string contentType,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record TranscriptionResult(
+    bool Success,
+    string? Text,
+    int? DurationSeconds,
+    string? Error);

--- a/src/Kursa.Application/Features/Recordings/Commands/TranscribeRecording.cs
+++ b/src/Kursa.Application/Features/Recordings/Commands/TranscribeRecording.cs
@@ -1,0 +1,47 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Recordings.Commands;
+
+public sealed record TranscribeRecordingCommand(Guid RecordingId) : IRequest<Result<bool>>;
+
+public sealed class TranscribeRecordingHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    ITranscriptionQueue transcriptionQueue) : IRequestHandler<TranscribeRecordingCommand, Result<bool>>
+{
+    public async Task<Result<bool>> Handle(TranscribeRecordingCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<bool>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<bool>.Failure("User not found.");
+
+        Recording? recording = await dbContext.Recordings
+            .FirstOrDefaultAsync(r => r.Id == request.RecordingId && r.UserId == user.Id, cancellationToken);
+
+        if (recording is null)
+            return Result<bool>.Failure("Recording not found.");
+
+        if (recording.Status == RecordingStatus.Transcribing)
+            return Result<bool>.Failure("Recording is already being transcribed.");
+
+        if (recording.Status == RecordingStatus.Completed || recording.Status == RecordingStatus.Transcribed)
+            return Result<bool>.Failure("Recording has already been transcribed.");
+
+        recording.Status = RecordingStatus.Transcribing;
+        recording.ErrorMessage = null;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        await transcriptionQueue.EnqueueAsync(recording.Id, cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+}

--- a/src/Kursa.Application/Features/Recordings/Commands/UploadRecording.cs
+++ b/src/Kursa.Application/Features/Recordings/Commands/UploadRecording.cs
@@ -18,7 +18,8 @@ public sealed record UploadRecordingCommand(
 public sealed class UploadRecordingHandler(
     ICurrentUserService currentUserService,
     IAppDbContext dbContext,
-    IFileStorageService fileStorage) : IRequestHandler<UploadRecordingCommand, Result<RecordingDto>>
+    IFileStorageService fileStorage,
+    ITranscriptionQueue transcriptionQueue) : IRequestHandler<UploadRecordingCommand, Result<RecordingDto>>
 {
     private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -81,6 +82,9 @@ public sealed class UploadRecordingHandler(
 
         dbContext.Recordings.Add(recording);
         await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Auto-enqueue transcription
+        await transcriptionQueue.EnqueueAsync(recording.Id, cancellationToken);
 
         string? courseTitle = request.CourseId.HasValue
             ? await dbContext.Courses

--- a/src/Kursa.Frontend/src/app/core/services/recording.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/recording.service.ts
@@ -72,6 +72,10 @@ export class RecordingService {
     return this.http.post<Recording>('/api/recordings/upload', formData);
   }
 
+  transcribe(id: string): Observable<void> {
+    return this.http.post<void>(`/api/recordings/${id}/transcribe`, {});
+  }
+
   delete(id: string): Observable<void> {
     return this.http.delete<void>(`/api/recordings/${id}`);
   }

--- a/src/Kursa.Frontend/src/app/features/recordings/recordings.component.ts
+++ b/src/Kursa.Frontend/src/app/features/recordings/recordings.component.ts
@@ -245,6 +245,14 @@ type View = 'list' | 'upload' | 'detail';
                 <div class="rounded-lg border border-border bg-card p-5">
                   <h2 class="text-sm font-semibold text-foreground">Actions</h2>
                   <div class="mt-3 space-y-2">
+                    @if (d.status === 'Uploaded' || d.status === 'Failed') {
+                      <button
+                        (click)="retryTranscription(d.id)"
+                        class="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                      >
+                        {{ d.status === 'Failed' ? 'Retry Transcription' : 'Start Transcription' }}
+                      </button>
+                    }
                     <button
                       (click)="downloadRecording(d.id)"
                       class="w-full rounded-md border border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
@@ -367,6 +375,12 @@ export class RecordingsComponent implements OnInit {
         this.detailLoading.set(false);
         this.view.set('list');
       },
+    });
+  }
+
+  retryTranscription(id: string): void {
+    this.recordingService.transcribe(id).subscribe({
+      next: () => this.openDetail(id),
     });
   }
 

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -73,6 +73,13 @@ public static class DependencyInjection
         // Summary service
         services.AddScoped<ISummaryService, SummaryService>();
 
+        // Whisper transcription
+        services.AddHttpClient("Whisper");
+        services.AddScoped<ITranscriptionService, WhisperTranscriptionService>();
+        services.AddSingleton<TranscriptionQueue>();
+        services.AddSingleton<ITranscriptionQueue>(sp => sp.GetRequiredService<TranscriptionQueue>());
+        services.AddHostedService<TranscriptionBackgroundService>();
+
         // LLM provider — configuration-driven selection
         services.AddSingleton<ILlmProvider>(sp =>
         {

--- a/src/Kursa.Infrastructure/Services/TranscriptionBackgroundService.cs
+++ b/src/Kursa.Infrastructure/Services/TranscriptionBackgroundService.cs
@@ -1,0 +1,95 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class TranscriptionBackgroundService(
+    IServiceScopeFactory scopeFactory,
+    TranscriptionQueue queue,
+    ILogger<TranscriptionBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Transcription background service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                Guid recordingId = await queue.DequeueAsync(stoppingToken);
+                await ProcessTranscriptionAsync(recordingId, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing transcription job");
+            }
+        }
+    }
+
+    private async Task ProcessTranscriptionAsync(Guid recordingId, CancellationToken cancellationToken)
+    {
+        using IServiceScope scope = scopeFactory.CreateScope();
+        IAppDbContext dbContext = scope.ServiceProvider.GetRequiredService<IAppDbContext>();
+        IFileStorageService fileStorage = scope.ServiceProvider.GetRequiredService<IFileStorageService>();
+        ITranscriptionService transcriptionService = scope.ServiceProvider.GetRequiredService<ITranscriptionService>();
+
+        Recording? recording = await dbContext.Recordings
+            .FirstOrDefaultAsync(r => r.Id == recordingId, cancellationToken);
+
+        if (recording is null)
+        {
+            logger.LogWarning("Recording {RecordingId} not found for transcription", recordingId);
+            return;
+        }
+
+        logger.LogInformation("Starting transcription for recording {RecordingId} ({Title})",
+            recordingId, recording.Title);
+
+        recording.Status = RecordingStatus.Transcribing;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            await using Stream audioStream = await fileStorage.DownloadAsync(recording.ObjectKey, cancellationToken);
+
+            TranscriptionResult result = await transcriptionService.TranscribeAsync(
+                audioStream, recording.ContentType, cancellationToken);
+
+            if (result.Success)
+            {
+                recording.TranscriptText = result.Text;
+                recording.DurationSeconds = result.DurationSeconds;
+                recording.TranscribedAt = DateTime.UtcNow;
+                recording.Status = RecordingStatus.Transcribed;
+                recording.ErrorMessage = null;
+
+                logger.LogInformation("Transcription completed for recording {RecordingId}", recordingId);
+            }
+            else
+            {
+                recording.Status = RecordingStatus.Failed;
+                recording.ErrorMessage = result.Error;
+
+                logger.LogError("Transcription failed for recording {RecordingId}: {Error}",
+                    recordingId, result.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            recording.Status = RecordingStatus.Failed;
+            recording.ErrorMessage = $"Transcription failed: {ex.Message}";
+
+            logger.LogError(ex, "Transcription failed for recording {RecordingId}", recordingId);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Kursa.Infrastructure/Services/TranscriptionQueue.cs
+++ b/src/Kursa.Infrastructure/Services/TranscriptionQueue.cs
@@ -1,0 +1,20 @@
+using System.Threading.Channels;
+using Kursa.Application.Common.Interfaces;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class TranscriptionQueue : ITranscriptionQueue
+{
+    private readonly Channel<Guid> _channel = Channel.CreateUnbounded<Guid>(
+        new UnboundedChannelOptions { SingleReader = true });
+
+    public ValueTask EnqueueAsync(Guid recordingId, CancellationToken cancellationToken = default)
+    {
+        return _channel.Writer.WriteAsync(recordingId, cancellationToken);
+    }
+
+    public ValueTask<Guid> DequeueAsync(CancellationToken cancellationToken)
+    {
+        return _channel.Reader.ReadAsync(cancellationToken);
+    }
+}

--- a/src/Kursa.Infrastructure/Services/WhisperTranscriptionService.cs
+++ b/src/Kursa.Infrastructure/Services/WhisperTranscriptionService.cs
@@ -1,0 +1,72 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Infrastructure.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class WhisperTranscriptionService(
+    IHttpClientFactory httpClientFactory,
+    IOptions<AudioProcessingOptions> options,
+    ILogger<WhisperTranscriptionService> logger) : ITranscriptionService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public async Task<TranscriptionResult> TranscribeAsync(
+        Stream audioStream,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpClient client = httpClientFactory.CreateClient("Whisper");
+            client.BaseAddress = new Uri(options.Value.WhisperUrl);
+            client.Timeout = TimeSpan.FromMinutes(30);
+
+            using var content = new MultipartFormDataContent();
+            var streamContent = new StreamContent(audioStream);
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            content.Add(streamContent, "file", "audio");
+
+            HttpResponseMessage response = await client.PostAsync("/transcribe", content, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                string errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                logger.LogError("Whisper transcription failed with status {Status}: {Body}",
+                    response.StatusCode, errorBody);
+                return new TranscriptionResult(false, null, null, $"Transcription service returned {response.StatusCode}");
+            }
+
+            string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            WhisperResponse? result = JsonSerializer.Deserialize<WhisperResponse>(responseBody, JsonOptions);
+
+            if (result is null)
+                return new TranscriptionResult(false, null, null, "Invalid response from transcription service.");
+
+            int? durationSeconds = result.Duration.HasValue ? (int)Math.Round(result.Duration.Value) : null;
+
+            return new TranscriptionResult(true, result.Text, durationSeconds, null);
+        }
+        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Whisper transcription failed");
+            return new TranscriptionResult(false, null, null, $"Transcription failed: {ex.Message}");
+        }
+    }
+
+    private sealed class WhisperResponse
+    {
+        public string? Text { get; init; }
+        public double? Duration { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary
- **ITranscriptionService** interface + **WhisperTranscriptionService** — HTTP client posting multipart audio to Whisper microservice at `/transcribe`
- **TranscriptionQueue** (Channel-based) + **TranscriptionBackgroundService** — async job processing for transcriptions
- Auto-enqueue transcription after upload (UploadRecordingCommand now triggers transcription automatically)
- **TranscribeRecording** command for manual retries on failed/uploaded recordings
- **POST /api/recordings/{id}/transcribe** endpoint
- Frontend: "Start Transcription" / "Retry Transcription" button in recording detail view

## Test plan
- [ ] Upload recording → verify transcription auto-enqueues
- [ ] Verify Whisper service receives audio via multipart POST
- [ ] Verify transcript text + duration stored on success
- [ ] Verify status transitions: Uploaded → Transcribing → Transcribed
- [ ] Verify Failed status + error message on Whisper errors
- [ ] Manual retry via POST endpoint and UI button

Closes #18