### PR TITLE
feat(recordings): add transcript viewer with segments, search, and export

### DIFF
--- a/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Kursa.Application/Common/Interfaces/IAppDbContext.cs
@@ -39,5 +39,7 @@ public interface IAppDbContext
 
     DbSet<Recording> Recordings { get; }
 
+    DbSet<TranscriptSegment> TranscriptSegments { get; }
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Common/Interfaces/ITranscriptionService.cs
+++ b/src/Kursa.Application/Common/Interfaces/ITranscriptionService.cs
@@ -12,4 +12,10 @@ public sealed record TranscriptionResult(
     bool Success,
     string? Text,
     int? DurationSeconds,
+    IReadOnlyList<TranscriptionSegment>? Segments,
     string? Error);
+
+public sealed record TranscriptionSegment(
+    double StartSeconds,
+    double EndSeconds,
+    string Text);

--- a/src/Kursa.Application/Features/Recordings/Queries/GetRecordingDetail.cs
+++ b/src/Kursa.Application/Features/Recordings/Queries/GetRecordingDetail.cs
@@ -1,5 +1,6 @@
 using Kursa.Application.Common.Interfaces;
 using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,28 +23,39 @@ public sealed class GetRecordingDetailHandler(
         if (user is null)
             return Result<RecordingDetailDto>.Failure("User not found.");
 
-        RecordingDetailDto? recording = await dbContext.Recordings
-            .Where(r => r.Id == request.RecordingId && r.UserId == user.Id)
-            .Select(r => new RecordingDetailDto(
-                r.Id,
-                r.Title,
-                r.Description,
-                r.CourseId,
-                r.Course != null ? r.Course.Name : null,
-                r.FileName,
-                r.ContentType,
-                r.FileSizeBytes,
-                r.DurationSeconds,
-                r.Status,
-                r.TranscriptText,
-                r.TranscribedAt,
-                r.ErrorMessage,
-                r.CreatedAt))
-            .FirstOrDefaultAsync(cancellationToken);
+        Recording? recording = await dbContext.Recordings
+            .Include(r => r.Course)
+            .Include(r => r.Segments.OrderBy(s => s.OrderIndex))
+            .FirstOrDefaultAsync(r => r.Id == request.RecordingId && r.UserId == user.Id, cancellationToken);
 
         if (recording is null)
             return Result<RecordingDetailDto>.Failure("Recording not found.");
 
-        return Result<RecordingDetailDto>.Success(recording);
+        List<TranscriptSegmentDto> segments = recording.Segments
+            .Select(s => new TranscriptSegmentDto(
+                s.Id,
+                s.OrderIndex,
+                s.StartSeconds,
+                s.EndSeconds,
+                s.Text,
+                s.Speaker))
+            .ToList();
+
+        return Result<RecordingDetailDto>.Success(new RecordingDetailDto(
+            recording.Id,
+            recording.Title,
+            recording.Description,
+            recording.CourseId,
+            recording.Course?.Name,
+            recording.FileName,
+            recording.ContentType,
+            recording.FileSizeBytes,
+            recording.DurationSeconds,
+            recording.Status,
+            recording.TranscriptText,
+            segments,
+            recording.TranscribedAt,
+            recording.ErrorMessage,
+            recording.CreatedAt));
     }
 }

--- a/src/Kursa.Application/Features/Recordings/RecordingDtos.cs
+++ b/src/Kursa.Application/Features/Recordings/RecordingDtos.cs
@@ -28,6 +28,15 @@ public sealed record RecordingDetailDto(
     int? DurationSeconds,
     RecordingStatus Status,
     string? TranscriptText,
+    IReadOnlyList<TranscriptSegmentDto> Segments,
     DateTime? TranscribedAt,
     string? ErrorMessage,
     DateTime CreatedAt);
+
+public sealed record TranscriptSegmentDto(
+    Guid Id,
+    int OrderIndex,
+    double StartSeconds,
+    double EndSeconds,
+    string Text,
+    string? Speaker);

--- a/src/Kursa.Domain/Entities/Recording.cs
+++ b/src/Kursa.Domain/Entities/Recording.cs
@@ -34,6 +34,8 @@ public class Recording : BaseEntity
     public DateTime? TranscribedAt { get; set; }
 
     public string? ErrorMessage { get; set; }
+
+    public ICollection<TranscriptSegment> Segments { get; set; } = new List<TranscriptSegment>();
 }
 
 public enum RecordingStatus

--- a/src/Kursa.Domain/Entities/TranscriptSegment.cs
+++ b/src/Kursa.Domain/Entities/TranscriptSegment.cs
@@ -1,0 +1,18 @@
+namespace Kursa.Domain.Entities;
+
+public class TranscriptSegment : BaseEntity
+{
+    public Guid RecordingId { get; set; }
+
+    public Recording Recording { get; set; } = null!;
+
+    public int OrderIndex { get; set; }
+
+    public double StartSeconds { get; set; }
+
+    public double EndSeconds { get; set; }
+
+    public required string Text { get; set; }
+
+    public string? Speaker { get; set; }
+}

--- a/src/Kursa.Frontend/src/app/core/services/recording.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/recording.service.ts
@@ -29,9 +29,19 @@ export interface RecordingDetail {
   durationSeconds: number | null;
   status: RecordingStatus;
   transcriptText: string | null;
+  segments: TranscriptSegment[];
   transcribedAt: string | null;
   errorMessage: string | null;
   createdAt: string;
+}
+
+export interface TranscriptSegment {
+  id: string;
+  orderIndex: number;
+  startSeconds: number;
+  endSeconds: number;
+  text: string;
+  speaker: string | null;
 }
 
 export type RecordingStatus =

--- a/src/Kursa.Frontend/src/app/features/recordings/recordings.component.ts
+++ b/src/Kursa.Frontend/src/app/features/recordings/recordings.component.ts
@@ -5,6 +5,7 @@ import {
   RecordingDetail,
   RecordingService,
   RecordingStatus,
+  TranscriptSegment,
 } from '../../core/services/recording.service';
 
 type View = 'list' | 'upload' | 'detail';
@@ -270,17 +271,65 @@ type View = 'list' | 'upload' | 'detail';
               </div>
             </div>
 
-            <!-- Transcript -->
+            <!-- Transcript Viewer -->
             @if (d.transcriptText) {
               <div class="rounded-lg border border-border bg-card p-5">
                 <div class="flex items-center justify-between">
                   <h2 class="text-sm font-semibold text-foreground">Transcript</h2>
-                  @if (d.transcribedAt) {
-                    <span class="text-xs text-muted-foreground">Transcribed {{ d.transcribedAt | date:'medium' }}</span>
+                  <div class="flex items-center gap-2">
+                    @if (d.transcribedAt) {
+                      <span class="text-xs text-muted-foreground">{{ d.transcribedAt | date:'medium' }}</span>
+                    }
+                    <button
+                      (click)="exportTranscript(d)"
+                      class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+                      aria-label="Export transcript"
+                    >
+                      Export
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Search -->
+                <div class="mt-3">
+                  <input
+                    #searchInput
+                    type="text"
+                    placeholder="Search transcript..."
+                    (input)="transcriptSearch.set(searchInput.value)"
+                    class="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  />
+                  @if (transcriptSearch()) {
+                    <p class="mt-1 text-xs text-muted-foreground">
+                      {{ filteredSegmentCount() }} matching segments
+                    </p>
                   }
                 </div>
-                <div class="mt-3 max-h-96 overflow-y-auto whitespace-pre-wrap text-sm text-foreground">
-                  {{ d.transcriptText }}
+
+                <!-- Segments or fallback to full text -->
+                <div class="mt-3 max-h-[32rem] overflow-y-auto">
+                  @if (d.segments.length > 0) {
+                    <div class="space-y-1">
+                      @for (seg of getFilteredSegments(d.segments); track seg.id) {
+                        <div
+                          class="flex gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-accent"
+                        >
+                          <button
+                            class="shrink-0 font-mono text-xs text-primary hover:underline"
+                            (click)="copyTimestamp(seg.startSeconds)"
+                            [attr.aria-label]="'Copy timestamp ' + formatTimestamp(seg.startSeconds)"
+                          >
+                            {{ formatTimestamp(seg.startSeconds) }}
+                          </button>
+                          <p class="text-sm text-foreground">{{ seg.text }}</p>
+                        </div>
+                      }
+                    </div>
+                  } @else {
+                    <div class="whitespace-pre-wrap text-sm text-foreground">
+                      {{ d.transcriptText }}
+                    </div>
+                  }
                 </div>
               </div>
             } @else if (d.status === 'Transcribing') {
@@ -311,6 +360,14 @@ export class RecordingsComponent implements OnInit {
   readonly uploadError = signal<string | null>(null);
   readonly detail = signal<RecordingDetail | null>(null);
   readonly detailLoading = signal(false);
+  readonly transcriptSearch = signal('');
+
+  readonly filteredSegmentCount = computed(() => {
+    const d = this.detail();
+    const search = this.transcriptSearch().toLowerCase();
+    if (!d || !search) return 0;
+    return d.segments.filter(s => s.text.toLowerCase().includes(search)).length;
+  });
 
   ngOnInit(): void {
     this.loadRecordings();
@@ -364,6 +421,7 @@ export class RecordingsComponent implements OnInit {
   openDetail(id: string): void {
     this.detailLoading.set(true);
     this.detail.set(null);
+    this.transcriptSearch.set('');
     this.view.set('detail');
 
     this.recordingService.getRecording(id).subscribe({
@@ -415,6 +473,43 @@ export class RecordingsComponent implements OnInit {
     if (h > 0) return `${h}h ${m}m ${s}s`;
     if (m > 0) return `${m}m ${s}s`;
     return `${s}s`;
+  }
+
+  getFilteredSegments(segments: TranscriptSegment[]): TranscriptSegment[] {
+    const search = this.transcriptSearch().toLowerCase();
+    if (!search) return segments;
+    return segments.filter(s => s.text.toLowerCase().includes(search));
+  }
+
+  formatTimestamp(seconds: number): string {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+    if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    return `${m}:${String(s).padStart(2, '0')}`;
+  }
+
+  copyTimestamp(seconds: number): void {
+    navigator.clipboard.writeText(this.formatTimestamp(seconds));
+  }
+
+  exportTranscript(d: RecordingDetail): void {
+    let content: string;
+    if (d.segments.length > 0) {
+      content = d.segments
+        .map(s => `[${this.formatTimestamp(s.startSeconds)}] ${s.text}`)
+        .join('\n');
+    } else {
+      content = d.transcriptText || '';
+    }
+
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${d.title} - Transcript.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
   }
 
   getStatusClasses(status: RecordingStatus): string {

--- a/src/Kursa.Infrastructure/Migrations/20260310222810_AddTranscriptSegments.Designer.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310222810_AddTranscriptSegments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kursa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Kursa.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310222810_AddTranscriptSegments")]
+    partial class AddTranscriptSegments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kursa.Infrastructure/Migrations/20260310222810_AddTranscriptSegments.cs
+++ b/src/Kursa.Infrastructure/Migrations/20260310222810_AddTranscriptSegments.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kursa.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTranscriptSegments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TranscriptSegments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    RecordingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrderIndex = table.Column<int>(type: "integer", nullable: false),
+                    StartSeconds = table.Column<double>(type: "double precision", nullable: false),
+                    EndSeconds = table.Column<double>(type: "double precision", nullable: false),
+                    Text = table.Column<string>(type: "text", nullable: false),
+                    Speaker = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TranscriptSegments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TranscriptSegments_Recordings_RecordingId",
+                        column: x => x.RecordingId,
+                        principalTable: "Recordings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TranscriptSegments_RecordingId",
+                table: "TranscriptSegments",
+                column: "RecordingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TranscriptSegments_RecordingId_OrderIndex",
+                table: "TranscriptSegments",
+                columns: new[] { "RecordingId", "OrderIndex" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TranscriptSegments");
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Kursa.Infrastructure/Persistence/AppDbContext.cs
@@ -40,6 +40,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     public DbSet<Recording> Recordings => Set<Recording>();
 
+    public DbSet<TranscriptSegment> TranscriptSegments => Set<TranscriptSegment>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);

--- a/src/Kursa.Infrastructure/Persistence/Configurations/TranscriptSegmentConfiguration.cs
+++ b/src/Kursa.Infrastructure/Persistence/Configurations/TranscriptSegmentConfiguration.cs
@@ -1,0 +1,24 @@
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Kursa.Infrastructure.Persistence.Configurations;
+
+public class TranscriptSegmentConfiguration : IEntityTypeConfiguration<TranscriptSegment>
+{
+    public void Configure(EntityTypeBuilder<TranscriptSegment> builder)
+    {
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Text).IsRequired();
+        builder.Property(s => s.Speaker).HasMaxLength(200);
+
+        builder.HasIndex(s => s.RecordingId);
+        builder.HasIndex(s => new { s.RecordingId, s.OrderIndex });
+
+        builder.HasOne(s => s.Recording)
+            .WithMany(r => r.Segments)
+            .HasForeignKey(s => s.RecordingId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Kursa.Infrastructure/Services/TranscriptionBackgroundService.cs
+++ b/src/Kursa.Infrastructure/Services/TranscriptionBackgroundService.cs
@@ -71,6 +71,31 @@ public sealed class TranscriptionBackgroundService(
                 recording.Status = RecordingStatus.Transcribed;
                 recording.ErrorMessage = null;
 
+                // Store segments if available
+                if (result.Segments is { Count: > 0 })
+                {
+                    // Remove existing segments (in case of retry)
+                    List<TranscriptSegment> existing = await dbContext.TranscriptSegments
+                        .Where(s => s.RecordingId == recordingId)
+                        .ToListAsync(cancellationToken);
+
+                    if (existing.Count > 0)
+                        dbContext.TranscriptSegments.RemoveRange(existing);
+
+                    for (int i = 0; i < result.Segments.Count; i++)
+                    {
+                        TranscriptionSegment seg = result.Segments[i];
+                        dbContext.TranscriptSegments.Add(new TranscriptSegment
+                        {
+                            RecordingId = recordingId,
+                            OrderIndex = i,
+                            StartSeconds = seg.StartSeconds,
+                            EndSeconds = seg.EndSeconds,
+                            Text = seg.Text,
+                        });
+                    }
+                }
+
                 logger.LogInformation("Transcription completed for recording {RecordingId}", recordingId);
             }
             else

--- a/src/Kursa.Infrastructure/Services/WhisperTranscriptionService.cs
+++ b/src/Kursa.Infrastructure/Services/WhisperTranscriptionService.cs
@@ -40,18 +40,23 @@ public sealed class WhisperTranscriptionService(
                 string errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
                 logger.LogError("Whisper transcription failed with status {Status}: {Body}",
                     response.StatusCode, errorBody);
-                return new TranscriptionResult(false, null, null, $"Transcription service returned {response.StatusCode}");
+                return new TranscriptionResult(false, null, null, null, $"Transcription service returned {response.StatusCode}");
             }
 
             string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
             WhisperResponse? result = JsonSerializer.Deserialize<WhisperResponse>(responseBody, JsonOptions);
 
             if (result is null)
-                return new TranscriptionResult(false, null, null, "Invalid response from transcription service.");
+                return new TranscriptionResult(false, null, null, null, "Invalid response from transcription service.");
 
             int? durationSeconds = result.Duration.HasValue ? (int)Math.Round(result.Duration.Value) : null;
 
-            return new TranscriptionResult(true, result.Text, durationSeconds, null);
+            List<TranscriptionSegment>? segments = result.Segments?
+                .Select(s => new TranscriptionSegment(s.Start, s.End, s.Text?.Trim() ?? ""))
+                .Where(s => !string.IsNullOrWhiteSpace(s.Text))
+                .ToList();
+
+            return new TranscriptionResult(true, result.Text, durationSeconds, segments, null);
         }
         catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -60,7 +65,7 @@ public sealed class WhisperTranscriptionService(
         catch (Exception ex)
         {
             logger.LogError(ex, "Whisper transcription failed");
-            return new TranscriptionResult(false, null, null, $"Transcription failed: {ex.Message}");
+            return new TranscriptionResult(false, null, null, null, $"Transcription failed: {ex.Message}");
         }
     }
 
@@ -68,5 +73,13 @@ public sealed class WhisperTranscriptionService(
     {
         public string? Text { get; init; }
         public double? Duration { get; init; }
+        public List<WhisperSegment>? Segments { get; init; }
+    }
+
+    private sealed class WhisperSegment
+    {
+        public double Start { get; init; }
+        public double End { get; init; }
+        public string? Text { get; init; }
     }
 }


### PR DESCRIPTION
## Summary
- **TranscriptSegment** entity with timestamps (startSeconds, endSeconds), linked to Recording
- Updated **WhisperTranscriptionService** to parse Whisper segment responses
- **TranscriptionBackgroundService** stores segments alongside full transcript text
- **Transcript viewer** with timestamped segments, search filtering, clickable timestamps (copy to clipboard), and text export
- Falls back to plain text display when segments aren't available

## Test plan
- [ ] Verify segments stored correctly from Whisper response
- [ ] Search within transcript filters segments in real-time
- [ ] Clickable timestamps copy to clipboard
- [ ] Export button generates text file with timestamps
- [ ] Plain text fallback works when no segments exist
- [ ] Retry transcription clears old segments before storing new ones

Closes #20