### PR TITLE
feat(recordings): connect recording pipeline to content indexing

### DIFF
--- a/src/Kursa.Application/Common/Interfaces/IRecordingIndexingService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IRecordingIndexingService.cs
@@ -1,0 +1,8 @@
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IRecordingIndexingService
+{
+    Task IndexRecordingAsync(Guid recordingId, CancellationToken cancellationToken = default);
+
+    Task RemoveRecordingIndexAsync(Guid recordingId, CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Features/Recordings/Commands/DeleteRecording.cs
+++ b/src/Kursa.Application/Features/Recordings/Commands/DeleteRecording.cs
@@ -10,7 +10,8 @@ public sealed record DeleteRecordingCommand(Guid RecordingId) : IRequest<Result<
 public sealed class DeleteRecordingHandler(
     ICurrentUserService currentUserService,
     IAppDbContext dbContext,
-    IFileStorageService fileStorage) : IRequestHandler<DeleteRecordingCommand, Result<bool>>
+    IFileStorageService fileStorage,
+    IRecordingIndexingService recordingIndexing) : IRequestHandler<DeleteRecordingCommand, Result<bool>>
 {
     public async Task<Result<bool>> Handle(DeleteRecordingCommand request, CancellationToken cancellationToken)
     {
@@ -30,6 +31,7 @@ public sealed class DeleteRecordingHandler(
             return Result<bool>.Failure("Recording not found.");
 
         await fileStorage.DeleteAsync(recording.ObjectKey, cancellationToken);
+        await recordingIndexing.RemoveRecordingIndexAsync(recording.Id, cancellationToken);
 
         dbContext.Recordings.Remove(recording);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -73,6 +73,9 @@ public static class DependencyInjection
         // Summary service
         services.AddScoped<ISummaryService, SummaryService>();
 
+        // Recording indexing (transcript → embeddings + summary)
+        services.AddScoped<IRecordingIndexingService, RecordingIndexingService>();
+
         // Whisper transcription
         services.AddHttpClient("Whisper");
         services.AddScoped<ITranscriptionService, WhisperTranscriptionService>();

--- a/src/Kursa.Infrastructure/Services/RecordingIndexingService.cs
+++ b/src/Kursa.Infrastructure/Services/RecordingIndexingService.cs
@@ -1,0 +1,136 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class RecordingIndexingService(
+    IAppDbContext dbContext,
+    ILlmProvider llmProvider,
+    IVectorStore vectorStore,
+    ILogger<RecordingIndexingService> logger) : IRecordingIndexingService
+{
+    private const string CollectionName = "content_chunks";
+    private const int ChunkSize = 512;
+    private const int ChunkOverlap = 64;
+
+    public async Task IndexRecordingAsync(Guid recordingId, CancellationToken cancellationToken = default)
+    {
+        Recording? recording = await dbContext.Recordings
+            .Include(r => r.Segments.OrderBy(s => s.OrderIndex))
+            .FirstOrDefaultAsync(r => r.Id == recordingId, cancellationToken);
+
+        if (recording is null)
+        {
+            logger.LogWarning("Recording {RecordingId} not found for indexing", recordingId);
+            return;
+        }
+
+        string text = BuildTranscriptText(recording);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            logger.LogInformation("No transcript text for recording {RecordingId}, skipping indexing", recordingId);
+            return;
+        }
+
+        IReadOnlyList<string> chunks = ContentPipeline.ChunkText(text, ChunkSize, ChunkOverlap);
+        if (chunks.Count == 0) return;
+
+        logger.LogInformation("Indexing recording {RecordingId} ({Title}): {ChunkCount} chunks",
+            recordingId, recording.Title, chunks.Count);
+
+        IReadOnlyList<float> firstEmbedding = await llmProvider.GenerateEmbeddingAsync(chunks[0], cancellationToken);
+        await vectorStore.EnsureCollectionAsync(CollectionName, firstEmbedding.Count, cancellationToken);
+
+        IReadOnlyList<IReadOnlyList<float>> embeddings = await llmProvider.GenerateEmbeddingsAsync(
+            chunks.ToList(), cancellationToken);
+
+        var points = new List<VectorPoint>(chunks.Count);
+        for (int i = 0; i < chunks.Count; i++)
+        {
+            points.Add(new VectorPoint
+            {
+                Id = Guid.NewGuid(),
+                Vector = embeddings[i],
+                ContentId = recordingId, // Use recording ID as content ID for vector store
+                UserId = recording.UserId,
+                ChunkText = chunks[i],
+                ChunkIndex = i,
+                ContentTitle = $"[Recording] {recording.Title}",
+                ContentType = "Recording",
+                SourceUrl = null,
+            });
+        }
+
+        // Delete existing vectors for this recording (re-index scenario)
+        await vectorStore.DeleteByContentIdAsync(CollectionName, recordingId, cancellationToken);
+
+        await vectorStore.UpsertAsync(CollectionName, points, cancellationToken);
+
+        // Generate summary
+        string summary = await GenerateSummaryAsync(text, cancellationToken);
+
+        recording.Status = RecordingStatus.Completed;
+
+        // Store summary in the description if it was empty, otherwise append
+        if (!string.IsNullOrWhiteSpace(summary))
+        {
+            recording.Description = string.IsNullOrWhiteSpace(recording.Description)
+                ? summary
+                : $"{recording.Description}\n\n---\n**AI Summary:**\n{summary}";
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Successfully indexed recording {RecordingId} ({Title}) with {ChunkCount} chunks",
+            recordingId, recording.Title, chunks.Count);
+    }
+
+    public async Task RemoveRecordingIndexAsync(Guid recordingId, CancellationToken cancellationToken = default)
+    {
+        await vectorStore.DeleteByContentIdAsync(CollectionName, recordingId, cancellationToken);
+        logger.LogInformation("Removed index for recording {RecordingId}", recordingId);
+    }
+
+    private static string BuildTranscriptText(Recording recording)
+    {
+        if (recording.Segments.Count > 0)
+        {
+            return string.Join("\n", recording.Segments.Select(s => s.Text));
+        }
+
+        return recording.TranscriptText ?? string.Empty;
+    }
+
+    private async Task<string> GenerateSummaryAsync(string text, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Truncate for summary to avoid token limits
+            string truncated = text.Length > 8000 ? text[..8000] : text;
+
+            string systemPrompt = """
+                You are a study assistant. Summarize the following lecture transcript concisely.
+                Focus on key topics, main concepts, and important takeaways.
+                Use bullet points for clarity. Keep it under 300 words.
+                """;
+
+            var request = new LlmChatRequest
+            {
+                SystemPrompt = systemPrompt,
+                Messages = [LlmMessage.User(truncated)],
+                Temperature = 0.3f,
+                MaxTokens = 500,
+            };
+
+            LlmChatResponse response = await llmProvider.ChatAsync(request, cancellationToken);
+            return response.Content;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to generate recording summary");
+            return string.Empty;
+        }
+    }
+}

--- a/src/Kursa.Infrastructure/Services/TranscriptionBackgroundService.cs
+++ b/src/Kursa.Infrastructure/Services/TranscriptionBackgroundService.cs
@@ -97,6 +97,13 @@ public sealed class TranscriptionBackgroundService(
                 }
 
                 logger.LogInformation("Transcription completed for recording {RecordingId}", recordingId);
+
+                await dbContext.SaveChangesAsync(cancellationToken);
+
+                // Chain: index the transcript for RAG search + generate summary
+                await IndexRecordingAsync(scope, recordingId, cancellationToken);
+
+                return;
             }
             else
             {
@@ -116,5 +123,29 @@ public sealed class TranscriptionBackgroundService(
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task IndexRecordingAsync(IServiceScope scope, Guid recordingId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            IRecordingIndexingService indexingService = scope.ServiceProvider.GetRequiredService<IRecordingIndexingService>();
+            await indexingService.IndexRecordingAsync(recordingId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Indexing failed for recording {RecordingId}, transcript is still available", recordingId);
+
+            // Don't fail the recording — transcript is still useful even without indexing
+            IAppDbContext dbContext = scope.ServiceProvider.GetRequiredService<IAppDbContext>();
+            Recording? recording = await dbContext.Recordings
+                .FirstOrDefaultAsync(r => r.Id == recordingId, cancellationToken);
+
+            if (recording is not null)
+            {
+                recording.Status = RecordingStatus.Transcribed;
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **RecordingIndexingService** — chunks transcript text using same chunking logic as content pipeline, generates embeddings via ILlmProvider, stores in Qdrant with `[Recording]` prefix in title and `Recording` content type
- **AI summary generation** — LLM generates concise bullet-point summary of lecture transcript, stored in recording description
- **Pipeline chain**: Upload → Transcribe → Index + Summarize → Completed
- **Delete cleanup** — removing a recording also removes its vector index from Qdrant
- **Graceful degradation** — if indexing fails, recording stays in `Transcribed` status (transcript still usable)
- Recording transcripts are now **searchable via RAG chat** alongside pinned Moodle content

## Test plan
- [ ] Upload recording → transcription → verify vectors stored in Qdrant
- [ ] Verify RAG chat can find content from recording transcripts
- [ ] Verify AI summary generated and stored in recording description
- [ ] Delete recording → verify vectors removed from Qdrant
- [ ] Verify indexing failure doesn't lose transcript (graceful fallback)

Closes #21