### PR TITLE
feat(assignments): add assignment tracker with deadlines and calendar view

### DIFF
--- a/src/Kursa.API/Controllers/MoodleController.cs
+++ b/src/Kursa.API/Controllers/MoodleController.cs
@@ -62,4 +62,15 @@ public class MoodleController(ISender sender) : ControllerBase
             ? Ok(result.Value)
             : BadRequest(result.Error);
     }
+
+    [HttpGet("assignments")]
+    public async Task<IActionResult> GetAssignmentsAsync(
+        [FromQuery] int? courseId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetAssignmentsQuery(courseId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
 }

--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -12,4 +12,8 @@ public interface IMoodleService
 
     Task<MoodleSiteInfoDto> GetSiteInfoAsync(
         string moodleUrl, string moodleToken, CancellationToken cancellationToken = default);
+
+    Task<MoodleAssignmentsResponseDto> GetAssignmentsAsync(
+        string moodleUrl, string moodleToken, IReadOnlyList<int>? courseIds = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Moodle/Models/MoodleAssignmentDtos.cs
+++ b/src/Kursa.Application/Features/Moodle/Models/MoodleAssignmentDtos.cs
@@ -1,0 +1,90 @@
+using System.Text.Json.Serialization;
+
+namespace Kursa.Application.Features.Moodle.Models;
+
+/// <summary>
+/// Wrapper returned by mod_assign_get_assignments.
+/// </summary>
+public sealed record MoodleAssignmentsResponseDto
+{
+    [JsonPropertyName("courses")]
+    public IReadOnlyList<MoodleAssignmentCourseDto> Courses { get; init; } = [];
+}
+
+/// <summary>
+/// A course containing its assignments.
+/// </summary>
+public sealed record MoodleAssignmentCourseDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("fullname")]
+    public string FullName { get; init; } = string.Empty;
+
+    [JsonPropertyName("shortname")]
+    public string ShortName { get; init; } = string.Empty;
+
+    [JsonPropertyName("assignments")]
+    public IReadOnlyList<MoodleAssignmentDto> Assignments { get; init; } = [];
+}
+
+/// <summary>
+/// A single Moodle assignment.
+/// </summary>
+public sealed record MoodleAssignmentDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("cmid")]
+    public int CmId { get; init; }
+
+    [JsonPropertyName("course")]
+    public int CourseId { get; init; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("intro")]
+    public string? Intro { get; init; }
+
+    [JsonPropertyName("duedate")]
+    public long DueDate { get; init; }
+
+    [JsonPropertyName("allowsubmissionsfromdate")]
+    public long AllowSubmissionsFromDate { get; init; }
+
+    [JsonPropertyName("cutoffdate")]
+    public long CutoffDate { get; init; }
+
+    [JsonPropertyName("timemodified")]
+    public long TimeModified { get; init; }
+
+    [JsonPropertyName("gradingduedate")]
+    public long GradingDueDate { get; init; }
+
+    [JsonPropertyName("nosubmissions")]
+    public int NoSubmissions { get; init; }
+
+    [JsonPropertyName("maxattempts")]
+    public int MaxAttempts { get; init; }
+}
+
+/// <summary>
+/// Flattened assignment DTO for the frontend, enriched with course info.
+/// </summary>
+public sealed record AssignmentViewDto
+{
+    public int Id { get; init; }
+    public int CourseId { get; init; }
+    public string CourseName { get; init; } = string.Empty;
+    public string CourseShortName { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public DateTime? DueDate { get; init; }
+    public DateTime? OpenDate { get; init; }
+    public DateTime? CutoffDate { get; init; }
+    public bool IsOverdue { get; init; }
+    public bool IsSubmittable { get; init; }
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetAssignments.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetAssignments.cs
@@ -1,0 +1,61 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record GetAssignmentsQuery(int? CourseId = null) : IRequest<Result<IReadOnlyList<AssignmentViewDto>>>;
+
+public sealed class GetAssignmentsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<GetAssignmentsQuery, Result<IReadOnlyList<AssignmentViewDto>>>
+{
+    public async Task<Result<IReadOnlyList<AssignmentViewDto>>> Handle(
+        GetAssignmentsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<AssignmentViewDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<AssignmentViewDto>>.Failure("User not found.");
+
+        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+            return Result<IReadOnlyList<AssignmentViewDto>>.Failure("Moodle account is not linked.");
+
+        IReadOnlyList<int>? courseIds = request.CourseId.HasValue
+            ? [request.CourseId.Value]
+            : null;
+
+        MoodleAssignmentsResponseDto response = await moodleService.GetAssignmentsAsync(
+            user.MoodleUrl, user.MoodleToken, courseIds, cancellationToken);
+
+        DateTime utcNow = DateTime.UtcNow;
+
+        var assignments = response.Courses
+            .SelectMany(course => course.Assignments.Select(a => new AssignmentViewDto
+            {
+                Id = a.Id,
+                CourseId = course.Id,
+                CourseName = course.FullName,
+                CourseShortName = course.ShortName,
+                Name = a.Name,
+                Description = a.Intro,
+                DueDate = a.DueDate > 0 ? DateTimeOffset.FromUnixTimeSeconds(a.DueDate).UtcDateTime : null,
+                OpenDate = a.AllowSubmissionsFromDate > 0 ? DateTimeOffset.FromUnixTimeSeconds(a.AllowSubmissionsFromDate).UtcDateTime : null,
+                CutoffDate = a.CutoffDate > 0 ? DateTimeOffset.FromUnixTimeSeconds(a.CutoffDate).UtcDateTime : null,
+                IsOverdue = a.DueDate > 0 && DateTimeOffset.FromUnixTimeSeconds(a.DueDate).UtcDateTime < utcNow,
+                IsSubmittable = a.NoSubmissions == 0,
+            }))
+            .OrderBy(a => a.DueDate ?? DateTime.MaxValue)
+            .ToList();
+
+        return Result<IReadOnlyList<AssignmentViewDto>>.Success(assignments);
+    }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -61,6 +61,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/recordings/recordings.component').then((m) => m.RecordingsComponent),
       },
+      {
+        path: 'assignments',
+        loadComponent: () =>
+          import('./features/assignments/assignments.component').then((m) => m.AssignmentsComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/assignment.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/assignment.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface AssignmentView {
+  id: number;
+  courseId: number;
+  courseName: string;
+  courseShortName: string;
+  name: string;
+  description: string | null;
+  dueDate: string | null;
+  openDate: string | null;
+  cutoffDate: string | null;
+  isOverdue: boolean;
+  isSubmittable: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AssignmentService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/moodle';
+
+  getAssignments(courseId?: number): Observable<AssignmentView[]> {
+    let params = new HttpParams();
+    if (courseId !== undefined) {
+      params = params.set('courseId', courseId.toString());
+    }
+    return this.http.get<AssignmentView[]>(`${this.baseUrl}/assignments`, { params });
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/assignments/assignments.component.ts
+++ b/src/Kursa.Frontend/src/app/features/assignments/assignments.component.ts
@@ -1,0 +1,355 @@
+import { ChangeDetectionStrategy, Component, signal, computed, inject, OnInit } from '@angular/core';
+import { AssignmentService, AssignmentView } from '../../core/services/assignment.service';
+
+interface CalendarDay {
+  date: Date;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  assignments: AssignmentView[];
+}
+
+@Component({
+  selector: 'app-assignments',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [],
+  template: `
+    <div class="mx-auto max-w-7xl space-y-6 p-6">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold text-foreground">Assignments</h1>
+          <p class="text-sm text-muted-foreground">Track your deadlines and submissions</p>
+        </div>
+        <div class="flex items-center gap-2 rounded-lg border border-border bg-card p-1">
+          <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+            [class]="activeView() === 'list' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'"
+            (click)="activeView.set('list')"
+          >
+            List
+          </button>
+          <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+            [class]="activeView() === 'calendar' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'"
+            (click)="activeView.set('calendar')"
+          >
+            Calendar
+          </button>
+        </div>
+      </div>
+
+      @if (loading()) {
+        <div class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" role="status">
+            <span class="sr-only">Loading assignments...</span>
+          </div>
+        </div>
+      } @else if (error()) {
+        <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          {{ error() }}
+        </div>
+      } @else if (activeView() === 'list') {
+        <!-- Filter tabs -->
+        <div class="flex gap-2">
+          <button
+            type="button"
+            class="rounded-full px-3 py-1 text-xs font-medium transition-colors"
+            [class]="filter() === 'all' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'"
+            (click)="filter.set('all')"
+          >
+            All ({{ assignments().length }})
+          </button>
+          <button
+            type="button"
+            class="rounded-full px-3 py-1 text-xs font-medium transition-colors"
+            [class]="filter() === 'upcoming' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'"
+            (click)="filter.set('upcoming')"
+          >
+            Upcoming ({{ upcomingCount() }})
+          </button>
+          <button
+            type="button"
+            class="rounded-full px-3 py-1 text-xs font-medium transition-colors"
+            [class]="filter() === 'overdue' ? 'bg-destructive text-destructive-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'"
+            (click)="filter.set('overdue')"
+          >
+            Overdue ({{ overdueCount() }})
+          </button>
+          <button
+            type="button"
+            class="rounded-full px-3 py-1 text-xs font-medium transition-colors"
+            [class]="filter() === 'no-date' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'"
+            (click)="filter.set('no-date')"
+          >
+            No deadline ({{ noDateCount() }})
+          </button>
+        </div>
+
+        @if (filteredAssignments().length === 0) {
+          <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
+            No assignments found.
+          </div>
+        } @else {
+          <div class="space-y-3">
+            @for (assignment of filteredAssignments(); track assignment.id) {
+              <div class="rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent/50">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <h3 class="truncate font-medium text-foreground">{{ assignment.name }}</h3>
+                      @if (assignment.isOverdue) {
+                        <span class="shrink-0 rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                          Overdue
+                        </span>
+                      }
+                    </div>
+                    <p class="mt-1 text-sm text-muted-foreground">{{ assignment.courseShortName }} — {{ assignment.courseName }}</p>
+                    @if (assignment.description) {
+                      <p class="mt-2 line-clamp-2 text-sm text-muted-foreground" [innerHTML]="assignment.description"></p>
+                    }
+                  </div>
+                  <div class="shrink-0 text-right">
+                    @if (assignment.dueDate) {
+                      <p class="text-sm font-medium" [class]="assignment.isOverdue ? 'text-destructive' : 'text-foreground'">
+                        {{ formatDate(assignment.dueDate) }}
+                      </p>
+                      <p class="text-xs text-muted-foreground">{{ formatRelative(assignment.dueDate) }}</p>
+                    } @else {
+                      <p class="text-sm text-muted-foreground">No deadline</p>
+                    }
+                  </div>
+                </div>
+              </div>
+            }
+          </div>
+        }
+      } @else {
+        <!-- Calendar View -->
+        <div class="rounded-lg border border-border bg-card">
+          <div class="flex items-center justify-between border-b border-border p-4">
+            <button
+              type="button"
+              class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              (click)="previousMonth()"
+              aria-label="Previous month"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="m15 18-6-6 6-6" /></svg>
+            </button>
+            <h2 class="text-lg font-semibold text-foreground">{{ monthLabel() }}</h2>
+            <button
+              type="button"
+              class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              (click)="nextMonth()"
+              aria-label="Next month"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="m9 18 6-6-6-6" /></svg>
+            </button>
+          </div>
+
+          <div class="grid grid-cols-7 border-b border-border">
+            @for (day of weekDays; track day) {
+              <div class="p-2 text-center text-xs font-medium text-muted-foreground">{{ day }}</div>
+            }
+          </div>
+
+          <div class="grid grid-cols-7">
+            @for (day of calendarDays(); track $index) {
+              <div
+                class="min-h-24 border-b border-r border-border p-1.5 last:border-r-0 [&:nth-child(7n)]:border-r-0"
+                [class.bg-accent/30]="day.isToday"
+                [class.opacity-40]="!day.isCurrentMonth"
+              >
+                <span
+                  class="inline-flex h-6 w-6 items-center justify-center rounded-full text-xs"
+                  [class]="day.isToday ? 'bg-primary text-primary-foreground font-bold' : 'text-foreground'"
+                >
+                  {{ day.date.getDate() }}
+                </span>
+                <div class="mt-1 space-y-0.5">
+                  @for (a of day.assignments; track a.id) {
+                    <div
+                      class="truncate rounded px-1 py-0.5 text-xs"
+                      [class]="a.isOverdue ? 'bg-destructive/10 text-destructive' : 'bg-primary/10 text-primary'"
+                      [title]="a.name + ' — ' + a.courseShortName"
+                    >
+                      {{ a.name }}
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  `,
+})
+export class AssignmentsComponent implements OnInit {
+  private readonly assignmentService = inject(AssignmentService);
+
+  readonly assignments = signal<AssignmentView[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly activeView = signal<'list' | 'calendar'>('list');
+  readonly filter = signal<'all' | 'upcoming' | 'overdue' | 'no-date'>('all');
+  readonly currentMonth = signal(new Date());
+
+  readonly weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+  readonly upcomingCount = computed(() =>
+    this.assignments().filter(a => a.dueDate && !a.isOverdue).length
+  );
+
+  readonly overdueCount = computed(() =>
+    this.assignments().filter(a => a.isOverdue).length
+  );
+
+  readonly noDateCount = computed(() =>
+    this.assignments().filter(a => !a.dueDate).length
+  );
+
+  readonly filteredAssignments = computed(() => {
+    const all = this.assignments();
+    switch (this.filter()) {
+      case 'upcoming':
+        return all.filter(a => a.dueDate && !a.isOverdue);
+      case 'overdue':
+        return all.filter(a => a.isOverdue);
+      case 'no-date':
+        return all.filter(a => !a.dueDate);
+      default:
+        return all;
+    }
+  });
+
+  readonly monthLabel = computed(() => {
+    const d = this.currentMonth();
+    return d.toLocaleString('default', { month: 'long', year: 'numeric' });
+  });
+
+  readonly calendarDays = computed<CalendarDay[]>(() => {
+    const current = this.currentMonth();
+    const year = current.getFullYear();
+    const month = current.getMonth();
+    const today = new Date();
+
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+
+    // Monday = 0 in our grid
+    let startOffset = firstDay.getDay() - 1;
+    if (startOffset < 0) startOffset = 6;
+
+    const days: CalendarDay[] = [];
+
+    // Previous month padding
+    for (let i = startOffset - 1; i >= 0; i--) {
+      const date = new Date(year, month, -i);
+      days.push({
+        date,
+        isCurrentMonth: false,
+        isToday: false,
+        assignments: this.getAssignmentsForDate(date),
+      });
+    }
+
+    // Current month
+    for (let d = 1; d <= lastDay.getDate(); d++) {
+      const date = new Date(year, month, d);
+      days.push({
+        date,
+        isCurrentMonth: true,
+        isToday:
+          date.getDate() === today.getDate() &&
+          date.getMonth() === today.getMonth() &&
+          date.getFullYear() === today.getFullYear(),
+        assignments: this.getAssignmentsForDate(date),
+      });
+    }
+
+    // Next month padding to fill the grid
+    const remaining = 7 - (days.length % 7);
+    if (remaining < 7) {
+      for (let i = 1; i <= remaining; i++) {
+        const date = new Date(year, month + 1, i);
+        days.push({
+          date,
+          isCurrentMonth: false,
+          isToday: false,
+          assignments: this.getAssignmentsForDate(date),
+        });
+      }
+    }
+
+    return days;
+  });
+
+  ngOnInit(): void {
+    this.loadAssignments();
+  }
+
+  previousMonth(): void {
+    const current = this.currentMonth();
+    this.currentMonth.set(new Date(current.getFullYear(), current.getMonth() - 1, 1));
+  }
+
+  nextMonth(): void {
+    const current = this.currentMonth();
+    this.currentMonth.set(new Date(current.getFullYear(), current.getMonth() + 1, 1));
+  }
+
+  formatDate(dateStr: string): string {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('default', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  formatRelative(dateStr: string): string {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = date.getTime() - now.getTime();
+    const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays < 0) {
+      const absDays = Math.abs(diffDays);
+      return absDays === 1 ? '1 day ago' : `${absDays} days ago`;
+    }
+    if (diffDays === 0) return 'Due today';
+    if (diffDays === 1) return 'Due tomorrow';
+    if (diffDays <= 7) return `Due in ${diffDays} days`;
+    const weeks = Math.floor(diffDays / 7);
+    return weeks === 1 ? 'Due in 1 week' : `Due in ${weeks} weeks`;
+  }
+
+  private loadAssignments(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.assignmentService.getAssignments().subscribe({
+      next: (assignments) => {
+        this.assignments.set(assignments);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load assignments. Make sure your Moodle account is linked.');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  private getAssignmentsForDate(date: Date): AssignmentView[] {
+    return this.assignments().filter(a => {
+      if (!a.dueDate) return false;
+      const due = new Date(a.dueDate);
+      return (
+        due.getDate() === date.getDate() &&
+        due.getMonth() === date.getMonth() &&
+        due.getFullYear() === date.getFullYear()
+      );
+    });
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -89,6 +89,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Recordings
         </a>
         <a
+          routerLink="/assignments"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M9 11l3 3L22 4" /><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" /></svg>
+          Assignments
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -71,6 +71,31 @@ public sealed class MoodleService(
             ?? throw new InvalidOperationException("Failed to deserialize Moodle site info.");
     }
 
+    public async Task<MoodleAssignmentsResponseDto> GetAssignmentsAsync(
+        string moodleUrl, string moodleToken, IReadOnlyList<int>? courseIds = null,
+        CancellationToken cancellationToken = default)
+    {
+        string courseParam = courseIds is { Count: > 0 }
+            ? "?" + string.Join("&", courseIds.Select((id, i) => $"courseids[{i}]={id}"))
+            : string.Empty;
+
+        string cacheKey = $"moodle:assignments:{HashToken(moodleToken)}:{courseParam.GetHashCode(StringComparison.Ordinal):x8}";
+
+        var cached = await GetFromCacheAsync<MoodleAssignmentsResponseDto>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, $"/mod_assign_get_assignments{courseParam}", cancellationToken);
+
+        var result = JsonSerializer.Deserialize<MoodleAssignmentsResponseDto>(response, JsonOptions)
+            ?? new MoodleAssignmentsResponseDto();
+
+        await SetCacheAsync(cacheKey, result, ContentCacheDuration, cancellationToken);
+
+        return result;
+    }
+
     private async Task<string> SendMoodleRequestAsync(
         string moodleUrl, string moodleToken, string endpoint, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary
- Lazy-load assignments from Moodle via MoodlewareAPI (`mod_assign_get_assignments`) — no local storage, following the project's lazy-loading philosophy
- Backend: `IMoodleService.GetAssignmentsAsync`, `GetAssignmentsQuery` CQRS handler with `AssignmentViewDto` flattening, `GET /api/moodle/assignments?courseId=` endpoint with Redis caching
- Frontend: `AssignmentsComponent` with **list view** (filter tabs: all/upcoming/overdue/no-date, relative date formatting) and **calendar view** (month navigation, assignments shown on due dates, today highlight)
- Sidebar navigation link added with checkmark icon

## Test plan
- [ ] Verify backend builds with 0 warnings (`dotnet build`)
- [ ] Verify frontend builds with 0 warnings (`bun run build`)
- [ ] Link Moodle account and verify assignments load from courses
- [ ] Test filter tabs (all/upcoming/overdue/no-date) show correct counts
- [ ] Test calendar view month navigation and assignment display on due dates
- [ ] Verify error state when Moodle is not linked

Closes #22