### PR TITLE
feat(grades): add grade viewer with trends per course

### DIFF
--- a/src/Kursa.API/Controllers/MoodleController.cs
+++ b/src/Kursa.API/Controllers/MoodleController.cs
@@ -73,4 +73,15 @@ public class MoodleController(ISender sender) : ControllerBase
             ? Ok(result.Value)
             : BadRequest(result.Error);
     }
+
+    [HttpGet("grades")]
+    public async Task<IActionResult> GetGradesAsync(
+        [FromQuery] int? courseId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetGradesQuery(courseId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
 }

--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -16,4 +16,7 @@ public interface IMoodleService
     Task<MoodleAssignmentsResponseDto> GetAssignmentsAsync(
         string moodleUrl, string moodleToken, IReadOnlyList<int>? courseIds = null,
         CancellationToken cancellationToken = default);
+
+    Task<MoodleGradeReportDto> GetGradesAsync(
+        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Moodle/Models/MoodleGradeDtos.cs
+++ b/src/Kursa.Application/Features/Moodle/Models/MoodleGradeDtos.cs
@@ -1,0 +1,120 @@
+using System.Text.Json.Serialization;
+
+namespace Kursa.Application.Features.Moodle.Models;
+
+/// <summary>
+/// Wrapper returned by gradereport_user_get_grade_items.
+/// </summary>
+public sealed record MoodleGradeReportDto
+{
+    [JsonPropertyName("usergrades")]
+    public IReadOnlyList<MoodleUserGradeDto> UserGrades { get; init; } = [];
+}
+
+/// <summary>
+/// Per-course grade report for a user.
+/// </summary>
+public sealed record MoodleUserGradeDto
+{
+    [JsonPropertyName("courseid")]
+    public int CourseId { get; init; }
+
+    [JsonPropertyName("courseidnumber")]
+    public string? CourseIdNumber { get; init; }
+
+    [JsonPropertyName("userfullname")]
+    public string UserFullName { get; init; } = string.Empty;
+
+    [JsonPropertyName("maxdepth")]
+    public int MaxDepth { get; init; }
+
+    [JsonPropertyName("gradeitems")]
+    public IReadOnlyList<MoodleGradeItemDto> GradeItems { get; init; } = [];
+}
+
+/// <summary>
+/// A single grade item (assignment, quiz, course total, etc.).
+/// </summary>
+public sealed record MoodleGradeItemDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("itemname")]
+    public string? ItemName { get; init; }
+
+    [JsonPropertyName("itemtype")]
+    public string ItemType { get; init; } = string.Empty;
+
+    [JsonPropertyName("itemmodule")]
+    public string? ItemModule { get; init; }
+
+    [JsonPropertyName("iteminstance")]
+    public int? ItemInstance { get; init; }
+
+    [JsonPropertyName("categoryid")]
+    public int? CategoryId { get; init; }
+
+    [JsonPropertyName("graderaw")]
+    public double? GradeRaw { get; init; }
+
+    [JsonPropertyName("gradeformatted")]
+    public string? GradeFormatted { get; init; }
+
+    [JsonPropertyName("grademin")]
+    public double GradeMin { get; init; }
+
+    [JsonPropertyName("grademax")]
+    public double GradeMax { get; init; }
+
+    [JsonPropertyName("percentageformatted")]
+    public string? PercentageFormatted { get; init; }
+
+    [JsonPropertyName("feedback")]
+    public string? Feedback { get; init; }
+
+    [JsonPropertyName("cmid")]
+    public int? CmId { get; init; }
+
+    [JsonPropertyName("weightraw")]
+    public double? WeightRaw { get; init; }
+
+    [JsonPropertyName("weightformatted")]
+    public string? WeightFormatted { get; init; }
+}
+
+/// <summary>
+/// Flattened grade view DTO for the frontend.
+/// </summary>
+public sealed record GradeViewDto
+{
+    public int Id { get; init; }
+    public int CourseId { get; init; }
+    public string CourseName { get; init; } = string.Empty;
+    public string? ItemName { get; init; }
+    public string ItemType { get; init; } = string.Empty;
+    public string? ItemModule { get; init; }
+    public double? Grade { get; init; }
+    public string? GradeFormatted { get; init; }
+    public double GradeMin { get; init; }
+    public double GradeMax { get; init; }
+    public string? Percentage { get; init; }
+    public string? Feedback { get; init; }
+    public string? Weight { get; init; }
+}
+
+/// <summary>
+/// Grade summary per course for the overview.
+/// </summary>
+public sealed record CourseGradeSummaryDto
+{
+    public int CourseId { get; init; }
+    public string CourseName { get; init; } = string.Empty;
+    public string? CourseTotal { get; init; }
+    public double? CourseTotalRaw { get; init; }
+    public double CourseTotalMax { get; init; }
+    public string? Percentage { get; init; }
+    public int GradedItemCount { get; init; }
+    public int TotalItemCount { get; init; }
+    public IReadOnlyList<GradeViewDto> Items { get; init; } = [];
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetGrades.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetGrades.cs
@@ -1,0 +1,112 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record GetGradesQuery(int? CourseId = null) : IRequest<Result<IReadOnlyList<CourseGradeSummaryDto>>>;
+
+public sealed class GetGradesHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<GetGradesQuery, Result<IReadOnlyList<CourseGradeSummaryDto>>>
+{
+    public async Task<Result<IReadOnlyList<CourseGradeSummaryDto>>> Handle(
+        GetGradesQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<CourseGradeSummaryDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<CourseGradeSummaryDto>>.Failure("User not found.");
+
+        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+            return Result<IReadOnlyList<CourseGradeSummaryDto>>.Failure("Moodle account is not linked.");
+
+        // If a specific course is requested, fetch just that one
+        if (request.CourseId.HasValue)
+        {
+            CourseGradeSummaryDto summary = await GetCourseGradeSummaryAsync(
+                user.MoodleUrl, user.MoodleToken, request.CourseId.Value, cancellationToken);
+            return Result<IReadOnlyList<CourseGradeSummaryDto>>.Success([summary]);
+        }
+
+        // Otherwise fetch grades for all enrolled courses
+        IReadOnlyList<MoodleCourseDto> courses = await moodleService.GetEnrolledCoursesAsync(
+            user.MoodleUrl, user.MoodleToken, cancellationToken);
+
+        var summaries = new List<CourseGradeSummaryDto>();
+        foreach (MoodleCourseDto course in courses)
+        {
+            CourseGradeSummaryDto summary = await GetCourseGradeSummaryAsync(
+                user.MoodleUrl, user.MoodleToken, course.Id, cancellationToken);
+
+            // Only include courses that have grade items
+            if (summary.TotalItemCount > 0)
+                summaries.Add(summary);
+        }
+
+        return Result<IReadOnlyList<CourseGradeSummaryDto>>.Success(summaries);
+    }
+
+    private async Task<CourseGradeSummaryDto> GetCourseGradeSummaryAsync(
+        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken)
+    {
+        MoodleGradeReportDto report = await moodleService.GetGradesAsync(
+            moodleUrl, moodleToken, courseId, cancellationToken);
+
+        MoodleUserGradeDto? userGrade = report.UserGrades.FirstOrDefault();
+
+        if (userGrade is null)
+        {
+            return new CourseGradeSummaryDto
+            {
+                CourseId = courseId,
+                CourseName = string.Empty,
+            };
+        }
+
+        // Separate course total from individual items
+        MoodleGradeItemDto? courseTotal = userGrade.GradeItems
+            .FirstOrDefault(g => g.ItemType == "course");
+
+        List<GradeViewDto> items = userGrade.GradeItems
+            .Where(g => g.ItemType != "course" && g.ItemType != "category")
+            .Select(g => new GradeViewDto
+            {
+                Id = g.Id,
+                CourseId = courseId,
+                CourseName = userGrade.UserFullName,
+                ItemName = g.ItemName,
+                ItemType = g.ItemType,
+                ItemModule = g.ItemModule,
+                Grade = g.GradeRaw,
+                GradeFormatted = g.GradeFormatted,
+                GradeMin = g.GradeMin,
+                GradeMax = g.GradeMax,
+                Percentage = g.PercentageFormatted,
+                Feedback = g.Feedback,
+                Weight = g.WeightFormatted,
+            })
+            .ToList();
+
+        return new CourseGradeSummaryDto
+        {
+            CourseId = courseId,
+            CourseName = userGrade.UserFullName,
+            CourseTotal = courseTotal?.GradeFormatted,
+            CourseTotalRaw = courseTotal?.GradeRaw,
+            CourseTotalMax = courseTotal?.GradeMax ?? 100,
+            Percentage = courseTotal?.PercentageFormatted,
+            GradedItemCount = items.Count(i => i.Grade.HasValue),
+            TotalItemCount = items.Count,
+            Items = items,
+        };
+    }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -66,6 +66,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/assignments/assignments.component').then((m) => m.AssignmentsComponent),
       },
+      {
+        path: 'grades',
+        loadComponent: () =>
+          import('./features/grades/grades.component').then((m) => m.GradesComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/grade.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/grade.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface GradeView {
+  id: number;
+  courseId: number;
+  courseName: string;
+  itemName: string | null;
+  itemType: string;
+  itemModule: string | null;
+  grade: number | null;
+  gradeFormatted: string | null;
+  gradeMin: number;
+  gradeMax: number;
+  percentage: string | null;
+  feedback: string | null;
+  weight: string | null;
+}
+
+export interface CourseGradeSummary {
+  courseId: number;
+  courseName: string;
+  courseTotal: string | null;
+  courseTotalRaw: number | null;
+  courseTotalMax: number;
+  percentage: string | null;
+  gradedItemCount: number;
+  totalItemCount: number;
+  items: GradeView[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class GradeService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/moodle';
+
+  getGrades(courseId?: number): Observable<CourseGradeSummary[]> {
+    let params = new HttpParams();
+    if (courseId !== undefined) {
+      params = params.set('courseId', courseId.toString());
+    }
+    return this.http.get<CourseGradeSummary[]>(`${this.baseUrl}/grades`, { params });
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/grades/grades.component.ts
+++ b/src/Kursa.Frontend/src/app/features/grades/grades.component.ts
@@ -1,0 +1,272 @@
+import { ChangeDetectionStrategy, Component, signal, computed, inject, OnInit } from '@angular/core';
+import { GradeService, CourseGradeSummary } from '../../core/services/grade.service';
+
+@Component({
+  selector: 'app-grades',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [],
+  template: `
+    <div class="mx-auto max-w-7xl space-y-6 p-6">
+      <div>
+        <h1 class="text-2xl font-bold text-foreground">Grades</h1>
+        <p class="text-sm text-muted-foreground">View your grades and track progress across courses</p>
+      </div>
+
+      @if (loading()) {
+        <div class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" role="status">
+            <span class="sr-only">Loading grades...</span>
+          </div>
+        </div>
+      } @else if (error()) {
+        <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          {{ error() }}
+        </div>
+      } @else if (courses().length === 0) {
+        <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
+          No grades available yet.
+        </div>
+      } @else {
+        <!-- Overview Cards -->
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div class="rounded-lg border border-border bg-card p-4">
+            <p class="text-xs font-medium text-muted-foreground">Courses</p>
+            <p class="mt-1 text-2xl font-bold text-foreground">{{ courses().length }}</p>
+          </div>
+          <div class="rounded-lg border border-border bg-card p-4">
+            <p class="text-xs font-medium text-muted-foreground">Graded Items</p>
+            <p class="mt-1 text-2xl font-bold text-foreground">{{ totalGraded() }}</p>
+          </div>
+          <div class="rounded-lg border border-border bg-card p-4">
+            <p class="text-xs font-medium text-muted-foreground">Average</p>
+            <p class="mt-1 text-2xl font-bold text-foreground">{{ averageGrade() }}</p>
+          </div>
+          <div class="rounded-lg border border-border bg-card p-4">
+            <p class="text-xs font-medium text-muted-foreground">Highest</p>
+            <p class="mt-1 text-2xl font-bold text-primary">{{ highestGrade() }}</p>
+          </div>
+        </div>
+
+        <!-- Course Grade Cards -->
+        <div class="space-y-4">
+          @for (course of courses(); track course.courseId) {
+            <div class="rounded-lg border border-border bg-card">
+              <!-- Course Header -->
+              <button
+                type="button"
+                class="flex w-full items-center justify-between p-4 text-left transition-colors hover:bg-accent/50"
+                (click)="toggleCourse(course.courseId)"
+                [attr.aria-expanded]="expandedCourses().has(course.courseId)"
+              >
+                <div class="min-w-0 flex-1">
+                  <h2 class="truncate font-semibold text-foreground">{{ course.courseName }}</h2>
+                  <p class="text-sm text-muted-foreground">
+                    {{ course.gradedItemCount }} of {{ course.totalItemCount }} items graded
+                  </p>
+                </div>
+                <div class="ml-4 flex items-center gap-4">
+                  @if (course.percentage) {
+                    <div class="text-right">
+                      <p class="text-lg font-bold" [class]="getGradeColor(course.courseTotalRaw, course.courseTotalMax)">
+                        {{ course.percentage }}
+                      </p>
+                      @if (course.courseTotal) {
+                        <p class="text-xs text-muted-foreground">{{ course.courseTotal }}</p>
+                      }
+                    </div>
+                  }
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                    class="h-5 w-5 text-muted-foreground transition-transform"
+                    [class.rotate-180]="expandedCourses().has(course.courseId)"
+                    aria-hidden="true"
+                  >
+                    <path d="m6 9 6 6 6-6" />
+                  </svg>
+                </div>
+              </button>
+
+              <!-- Grade Items (expandable) -->
+              @if (expandedCourses().has(course.courseId)) {
+                <div class="border-t border-border">
+                  @if (course.items.length === 0) {
+                    <p class="p-4 text-sm text-muted-foreground">No grade items in this course.</p>
+                  } @else {
+                    <div class="overflow-x-auto">
+                      <table class="w-full text-sm" role="table">
+                        <thead>
+                          <tr class="border-b border-border text-left">
+                            <th class="p-3 font-medium text-muted-foreground">Item</th>
+                            <th class="p-3 font-medium text-muted-foreground">Type</th>
+                            <th class="p-3 text-right font-medium text-muted-foreground">Grade</th>
+                            <th class="p-3 text-right font-medium text-muted-foreground">Percentage</th>
+                            <th class="p-3 text-right font-medium text-muted-foreground">Weight</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          @for (item of course.items; track item.id) {
+                            <tr class="border-b border-border/50 last:border-b-0">
+                              <td class="p-3">
+                                <div class="flex items-center gap-2">
+                                  <span class="inline-flex h-6 w-6 items-center justify-center rounded text-xs" [class]="getModuleBadgeClass(item.itemModule)">
+                                    {{ getModuleIcon(item.itemModule) }}
+                                  </span>
+                                  <span class="text-foreground">{{ item.itemName ?? 'Unnamed item' }}</span>
+                                </div>
+                              </td>
+                              <td class="p-3 text-muted-foreground capitalize">{{ item.itemModule ?? item.itemType }}</td>
+                              <td class="p-3 text-right">
+                                @if (item.gradeFormatted) {
+                                  <span [class]="getGradeColor(item.grade, item.gradeMax)">
+                                    {{ item.gradeFormatted }}
+                                  </span>
+                                } @else {
+                                  <span class="text-muted-foreground">—</span>
+                                }
+                              </td>
+                              <td class="p-3 text-right">
+                                @if (item.percentage) {
+                                  <span [class]="getGradeColor(item.grade, item.gradeMax)">{{ item.percentage }}</span>
+                                } @else {
+                                  <span class="text-muted-foreground">—</span>
+                                }
+                              </td>
+                              <td class="p-3 text-right text-muted-foreground">
+                                {{ item.weight ?? '—' }}
+                              </td>
+                            </tr>
+                          }
+                        </tbody>
+                      </table>
+                    </div>
+                  }
+
+                  <!-- Grade Trend Bar -->
+                  @if (getGradedItems(course).length > 1) {
+                    <div class="border-t border-border p-4">
+                      <h3 class="mb-3 text-xs font-medium text-muted-foreground">Grade Trend</h3>
+                      <div class="flex items-end gap-1" style="height: 80px" role="img" [attr.aria-label]="'Grade trend for ' + course.courseName">
+                        @for (item of getGradedItems(course); track item.id) {
+                          <div
+                            class="flex-1 rounded-t transition-colors"
+                            [class]="getBarColor(item.grade, item.gradeMax)"
+                            [style.height.%]="getBarHeight(item.grade, item.gradeMax)"
+                            [title]="(item.itemName ?? 'Item') + ': ' + (item.percentage ?? 'N/A')"
+                          ></div>
+                        }
+                      </div>
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class GradesComponent implements OnInit {
+  private readonly gradeService = inject(GradeService);
+
+  readonly courses = signal<CourseGradeSummary[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly expandedCourses = signal<Set<number>>(new Set());
+
+  readonly totalGraded = computed(() =>
+    this.courses().reduce((sum, c) => sum + c.gradedItemCount, 0)
+  );
+
+  readonly averageGrade = computed(() => {
+    const all = this.courses().filter(c => c.courseTotalRaw != null);
+    if (all.length === 0) return '—';
+    const avg = all.reduce((sum, c) => sum + ((c.courseTotalRaw ?? 0) / c.courseTotalMax) * 100, 0) / all.length;
+    return `${avg.toFixed(1)}%`;
+  });
+
+  readonly highestGrade = computed(() => {
+    const all = this.courses().filter(c => c.courseTotalRaw != null);
+    if (all.length === 0) return '—';
+    const max = Math.max(...all.map(c => ((c.courseTotalRaw ?? 0) / c.courseTotalMax) * 100));
+    return `${max.toFixed(1)}%`;
+  });
+
+  ngOnInit(): void {
+    this.loadGrades();
+  }
+
+  toggleCourse(courseId: number): void {
+    this.expandedCourses.update(set => {
+      const next = new Set(set);
+      if (next.has(courseId)) {
+        next.delete(courseId);
+      } else {
+        next.add(courseId);
+      }
+      return next;
+    });
+  }
+
+  getGradeColor(grade: number | null | undefined, max: number): string {
+    if (grade == null) return 'text-muted-foreground';
+    const pct = (grade / max) * 100;
+    if (pct >= 80) return 'text-green-500';
+    if (pct >= 60) return 'text-yellow-500';
+    if (pct >= 40) return 'text-orange-500';
+    return 'text-destructive';
+  }
+
+  getModuleBadgeClass(module: string | null): string {
+    switch (module) {
+      case 'assign': return 'bg-blue-500/10 text-blue-500';
+      case 'quiz': return 'bg-purple-500/10 text-purple-500';
+      case 'forum': return 'bg-green-500/10 text-green-500';
+      default: return 'bg-muted text-muted-foreground';
+    }
+  }
+
+  getModuleIcon(module: string | null): string {
+    switch (module) {
+      case 'assign': return 'A';
+      case 'quiz': return 'Q';
+      case 'forum': return 'F';
+      default: return 'G';
+    }
+  }
+
+  getGradedItems(course: CourseGradeSummary): CourseGradeSummary['items'] {
+    return course.items.filter(i => i.grade != null);
+  }
+
+  getBarHeight(grade: number | null | undefined, max: number): number {
+    if (grade == null || max === 0) return 0;
+    return Math.max(5, (grade / max) * 100);
+  }
+
+  getBarColor(grade: number | null | undefined, max: number): string {
+    if (grade == null) return 'bg-muted';
+    const pct = (grade / max) * 100;
+    if (pct >= 80) return 'bg-green-500';
+    if (pct >= 60) return 'bg-yellow-500';
+    if (pct >= 40) return 'bg-orange-500';
+    return 'bg-destructive';
+  }
+
+  private loadGrades(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.gradeService.getGrades().subscribe({
+      next: (courses) => {
+        this.courses.set(courses);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load grades. Make sure your Moodle account is linked.');
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -97,6 +97,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Assignments
         </a>
         <a
+          routerLink="/grades"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>
+          Grades
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -96,6 +96,26 @@ public sealed class MoodleService(
         return result;
     }
 
+    public async Task<MoodleGradeReportDto> GetGradesAsync(
+        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default)
+    {
+        string cacheKey = $"moodle:grades:{HashToken(moodleToken)}:{courseId}";
+
+        var cached = await GetFromCacheAsync<MoodleGradeReportDto>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, $"/gradereport_user_get_grade_items?courseid={courseId}", cancellationToken);
+
+        var result = JsonSerializer.Deserialize<MoodleGradeReportDto>(response, JsonOptions)
+            ?? new MoodleGradeReportDto();
+
+        await SetCacheAsync(cacheKey, result, ContentCacheDuration, cancellationToken);
+
+        return result;
+    }
+
     private async Task<string> SendMoodleRequestAsync(
         string moodleUrl, string moodleToken, string endpoint, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary
- Lazy-load grades from Moodle via `gradereport_user_get_grade_items` — fetches per-course grade items with caching
- Backend: `GetGradesQuery` aggregates grades into `CourseGradeSummaryDto` with course totals, graded item counts, and individual grade items
- Frontend: Overview stat cards (courses, graded items, average, highest), expandable course cards with grade tables (item name, type, grade, percentage, weight), color-coded grades, module type badges, and bar chart grade trends

## Test plan
- [ ] Backend and frontend build with 0 warnings
- [ ] Link Moodle account and verify grades load per course
- [ ] Expand course cards to see individual grade items
- [ ] Verify color coding (green >= 80%, yellow >= 60%, orange >= 40%, red < 40%)
- [ ] Verify grade trend bars appear for courses with multiple graded items

Closes #23