### PR TITLE
feat(forums): add forum/discussion proxy from Moodle

### DIFF
--- a/src/Kursa.API/Controllers/MoodleController.cs
+++ b/src/Kursa.API/Controllers/MoodleController.cs
@@ -84,4 +84,24 @@ public class MoodleController(ISender sender) : ControllerBase
             ? Ok(result.Value)
             : BadRequest(result.Error);
     }
+
+    [HttpGet("courses/{courseId:int}/forums")]
+    public async Task<IActionResult> GetForumsAsync(int courseId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetForumsQuery(courseId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+
+    [HttpGet("forums/{forumId:int}/discussions")]
+    public async Task<IActionResult> GetForumDiscussionsAsync(int forumId, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetForumDiscussionsQuery(forumId), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
 }

--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -19,4 +19,10 @@ public interface IMoodleService
 
     Task<MoodleGradeReportDto> GetGradesAsync(
         string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MoodleForumDto>> GetForumsAsync(
+        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default);
+
+    Task<MoodleForumDiscussionsResponseDto> GetForumDiscussionsAsync(
+        string moodleUrl, string moodleToken, int forumId, CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Moodle/Models/MoodleForumDtos.cs
+++ b/src/Kursa.Application/Features/Moodle/Models/MoodleForumDtos.cs
@@ -1,0 +1,111 @@
+using System.Text.Json.Serialization;
+
+namespace Kursa.Application.Features.Moodle.Models;
+
+/// <summary>
+/// A Moodle forum instance returned by mod_forum_get_forums_by_courses.
+/// </summary>
+public sealed record MoodleForumDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("course")]
+    public int CourseId { get; init; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("intro")]
+    public string? Intro { get; init; }
+
+    [JsonPropertyName("cmid")]
+    public int CmId { get; init; }
+
+    [JsonPropertyName("numdiscussions")]
+    public int NumDiscussions { get; init; }
+
+    [JsonPropertyName("timemodified")]
+    public long TimeModified { get; init; }
+}
+
+/// <summary>
+/// Wrapper for forum discussions response.
+/// </summary>
+public sealed record MoodleForumDiscussionsResponseDto
+{
+    [JsonPropertyName("discussions")]
+    public IReadOnlyList<MoodleDiscussionDto> Discussions { get; init; } = [];
+}
+
+/// <summary>
+/// A single forum discussion.
+/// </summary>
+public sealed record MoodleDiscussionDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+
+    [JsonPropertyName("userfullname")]
+    public string UserFullName { get; init; } = string.Empty;
+
+    [JsonPropertyName("userpictureurl")]
+    public string? UserPictureUrl { get; init; }
+
+    [JsonPropertyName("created")]
+    public long Created { get; init; }
+
+    [JsonPropertyName("modified")]
+    public long Modified { get; init; }
+
+    [JsonPropertyName("numreplies")]
+    public int NumReplies { get; init; }
+
+    [JsonPropertyName("pinned")]
+    public bool Pinned { get; init; }
+
+    [JsonPropertyName("subject")]
+    public string? Subject { get; init; }
+
+    [JsonPropertyName("timemodified")]
+    public long TimeModified { get; init; }
+}
+
+/// <summary>
+/// Flattened forum view for the frontend.
+/// </summary>
+public sealed record ForumViewDto
+{
+    public int Id { get; init; }
+    public int CourseId { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string Type { get; init; } = string.Empty;
+    public int DiscussionCount { get; init; }
+    public DateTime? LastModified { get; init; }
+}
+
+/// <summary>
+/// Discussion view for the frontend.
+/// </summary>
+public sealed record DiscussionViewDto
+{
+    public int Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string? Message { get; init; }
+    public string Author { get; init; } = string.Empty;
+    public string? AuthorAvatar { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime ModifiedAt { get; init; }
+    public int ReplyCount { get; init; }
+    public bool IsPinned { get; init; }
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetForumDiscussions.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetForumDiscussions.cs
@@ -1,0 +1,54 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record GetForumDiscussionsQuery(int ForumId) : IRequest<Result<IReadOnlyList<DiscussionViewDto>>>;
+
+public sealed class GetForumDiscussionsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<GetForumDiscussionsQuery, Result<IReadOnlyList<DiscussionViewDto>>>
+{
+    public async Task<Result<IReadOnlyList<DiscussionViewDto>>> Handle(
+        GetForumDiscussionsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<DiscussionViewDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<DiscussionViewDto>>.Failure("User not found.");
+
+        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+            return Result<IReadOnlyList<DiscussionViewDto>>.Failure("Moodle account is not linked.");
+
+        MoodleForumDiscussionsResponseDto response = await moodleService.GetForumDiscussionsAsync(
+            user.MoodleUrl, user.MoodleToken, request.ForumId, cancellationToken);
+
+        var result = response.Discussions
+            .Select(d => new DiscussionViewDto
+            {
+                Id = d.Id,
+                Title = d.Name,
+                Message = d.Message,
+                Author = d.UserFullName,
+                AuthorAvatar = d.UserPictureUrl,
+                CreatedAt = DateTimeOffset.FromUnixTimeSeconds(d.Created).UtcDateTime,
+                ModifiedAt = DateTimeOffset.FromUnixTimeSeconds(d.Modified).UtcDateTime,
+                ReplyCount = d.NumReplies,
+                IsPinned = d.Pinned,
+            })
+            .OrderByDescending(d => d.IsPinned)
+            .ThenByDescending(d => d.ModifiedAt)
+            .ToList();
+
+        return Result<IReadOnlyList<DiscussionViewDto>>.Success(result);
+    }
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetForums.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetForums.cs
@@ -1,0 +1,50 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record GetForumsQuery(int CourseId) : IRequest<Result<IReadOnlyList<ForumViewDto>>>;
+
+public sealed class GetForumsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<GetForumsQuery, Result<IReadOnlyList<ForumViewDto>>>
+{
+    public async Task<Result<IReadOnlyList<ForumViewDto>>> Handle(
+        GetForumsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<ForumViewDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<ForumViewDto>>.Failure("User not found.");
+
+        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+            return Result<IReadOnlyList<ForumViewDto>>.Failure("Moodle account is not linked.");
+
+        IReadOnlyList<MoodleForumDto> forums = await moodleService.GetForumsAsync(
+            user.MoodleUrl, user.MoodleToken, request.CourseId, cancellationToken);
+
+        var result = forums.Select(f => new ForumViewDto
+        {
+            Id = f.Id,
+            CourseId = f.CourseId,
+            Name = f.Name,
+            Description = f.Intro,
+            Type = f.Type,
+            DiscussionCount = f.NumDiscussions,
+            LastModified = f.TimeModified > 0
+                ? DateTimeOffset.FromUnixTimeSeconds(f.TimeModified).UtcDateTime
+                : null,
+        }).ToList();
+
+        return Result<IReadOnlyList<ForumViewDto>>.Success(result);
+    }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -71,6 +71,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/grades/grades.component').then((m) => m.GradesComponent),
       },
+      {
+        path: 'forums',
+        loadComponent: () =>
+          import('./features/forums/forums.component').then((m) => m.ForumsComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/forum.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/forum.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface ForumView {
+  id: number;
+  courseId: number;
+  name: string;
+  description: string | null;
+  type: string;
+  discussionCount: number;
+  lastModified: string | null;
+}
+
+export interface DiscussionView {
+  id: number;
+  title: string;
+  message: string | null;
+  author: string;
+  authorAvatar: string | null;
+  createdAt: string;
+  modifiedAt: string;
+  replyCount: number;
+  isPinned: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ForumService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/moodle';
+
+  getForums(courseId: number): Observable<ForumView[]> {
+    return this.http.get<ForumView[]>(`${this.baseUrl}/courses/${courseId}/forums`);
+  }
+
+  getDiscussions(forumId: number): Observable<DiscussionView[]> {
+    return this.http.get<DiscussionView[]>(`${this.baseUrl}/forums/${forumId}/discussions`);
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/forums/forums.component.ts
+++ b/src/Kursa.Frontend/src/app/features/forums/forums.component.ts
@@ -1,0 +1,254 @@
+import { ChangeDetectionStrategy, Component, signal, computed, inject, OnInit } from '@angular/core';
+import { ForumService, ForumView, DiscussionView } from '../../core/services/forum.service';
+import { MoodleService, MoodleCourse } from '../../core/services/moodle.service';
+
+@Component({
+  selector: 'app-forums',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [],
+  template: `
+    <div class="mx-auto max-w-7xl space-y-6 p-6">
+      <div>
+        <h1 class="text-2xl font-bold text-foreground">Forums</h1>
+        <p class="text-sm text-muted-foreground">Browse and follow course discussions</p>
+      </div>
+
+      @if (loading()) {
+        <div class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+      } @else if (error()) {
+        <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          {{ error() }}
+        </div>
+      } @else if (activeView() === 'courses') {
+        <!-- Course Selection -->
+        @if (courses().length === 0) {
+          <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
+            No courses found. Link your Moodle account first.
+          </div>
+        } @else {
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            @for (course of courses(); track course.id) {
+              <button
+                type="button"
+                class="rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-accent/50"
+                (click)="selectCourse(course)"
+              >
+                <h3 class="font-medium text-foreground">{{ course.shortName }}</h3>
+                <p class="mt-1 text-sm text-muted-foreground line-clamp-2">{{ course.fullName }}</p>
+              </button>
+            }
+          </div>
+        }
+      } @else if (activeView() === 'forums') {
+        <!-- Forum List -->
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            (click)="backToCourses()"
+            aria-label="Back to courses"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="m15 18-6-6 6-6" /></svg>
+          </button>
+          <h2 class="text-lg font-semibold text-foreground">{{ selectedCourseName() }}</h2>
+        </div>
+
+        @if (forums().length === 0) {
+          <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
+            No forums in this course.
+          </div>
+        } @else {
+          <div class="space-y-3">
+            @for (forum of forums(); track forum.id) {
+              <button
+                type="button"
+                class="w-full rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-accent/50"
+                (click)="selectForum(forum)"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0 flex-1">
+                    <h3 class="font-medium text-foreground">{{ forum.name }}</h3>
+                    @if (forum.description) {
+                      <p class="mt-1 line-clamp-2 text-sm text-muted-foreground" [innerHTML]="forum.description"></p>
+                    }
+                  </div>
+                  <div class="shrink-0 text-right">
+                    <span class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                      {{ forum.discussionCount }} discussions
+                    </span>
+                  </div>
+                </div>
+              </button>
+            }
+          </div>
+        }
+      } @else {
+        <!-- Discussion List -->
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            (click)="backToForums()"
+            aria-label="Back to forums"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="m15 18-6-6 6-6" /></svg>
+          </button>
+          <h2 class="text-lg font-semibold text-foreground">{{ selectedForumName() }}</h2>
+        </div>
+
+        @if (discussionsLoading()) {
+          <div class="flex items-center justify-center py-8">
+            <div class="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" role="status">
+              <span class="sr-only">Loading discussions...</span>
+            </div>
+          </div>
+        } @else if (discussions().length === 0) {
+          <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
+            No discussions yet in this forum.
+          </div>
+        } @else {
+          <div class="space-y-3">
+            @for (discussion of discussions(); track discussion.id) {
+              <div class="rounded-lg border border-border bg-card p-4">
+                <div class="flex items-start gap-3">
+                  @if (discussion.authorAvatar) {
+                    <img
+                      [src]="discussion.authorAvatar"
+                      [alt]="discussion.author"
+                      class="h-10 w-10 rounded-full"
+                    />
+                  } @else {
+                    <div class="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary">
+                      {{ getInitials(discussion.author) }}
+                    </div>
+                  }
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <h3 class="font-medium text-foreground">{{ discussion.title }}</h3>
+                      @if (discussion.isPinned) {
+                        <span class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">Pinned</span>
+                      }
+                    </div>
+                    <div class="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+                      <span>{{ discussion.author }}</span>
+                      <span>{{ formatDate(discussion.createdAt) }}</span>
+                      <span>{{ discussion.replyCount }} replies</span>
+                    </div>
+                    @if (discussion.message) {
+                      <div class="mt-2 line-clamp-3 text-sm text-muted-foreground" [innerHTML]="discussion.message"></div>
+                    }
+                  </div>
+                </div>
+              </div>
+            }
+          </div>
+        }
+      }
+    </div>
+  `,
+})
+export class ForumsComponent implements OnInit {
+  private readonly forumService = inject(ForumService);
+  private readonly moodleService = inject(MoodleService);
+
+  readonly courses = signal<MoodleCourse[]>([]);
+  readonly forums = signal<ForumView[]>([]);
+  readonly discussions = signal<DiscussionView[]>([]);
+  readonly loading = signal(true);
+  readonly discussionsLoading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly activeView = signal<'courses' | 'forums' | 'discussions'>('courses');
+  readonly selectedCourseName = signal('');
+  readonly selectedForumName = signal('');
+
+  private selectedCourseId = 0;
+
+  ngOnInit(): void {
+    this.loadCourses();
+  }
+
+  selectCourse(course: MoodleCourse): void {
+    this.selectedCourseId = course.id;
+    this.selectedCourseName.set(course.shortName);
+    this.loading.set(true);
+    this.activeView.set('forums');
+
+    this.forumService.getForums(course.id).subscribe({
+      next: (forums) => {
+        this.forums.set(forums);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load forums.');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  selectForum(forum: ForumView): void {
+    this.selectedForumName.set(forum.name);
+    this.discussionsLoading.set(true);
+    this.activeView.set('discussions');
+
+    this.forumService.getDiscussions(forum.id).subscribe({
+      next: (discussions) => {
+        this.discussions.set(discussions);
+        this.discussionsLoading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load discussions.');
+        this.discussionsLoading.set(false);
+      },
+    });
+  }
+
+  backToCourses(): void {
+    this.activeView.set('courses');
+    this.forums.set([]);
+    this.error.set(null);
+  }
+
+  backToForums(): void {
+    this.activeView.set('forums');
+    this.discussions.set([]);
+    this.error.set(null);
+  }
+
+  getInitials(name: string): string {
+    return name
+      .split(' ')
+      .map(p => p[0])
+      .join('')
+      .substring(0, 2)
+      .toUpperCase();
+  }
+
+  formatDate(dateStr: string): string {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('default', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  private loadCourses(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.moodleService.getEnrolledCourses().subscribe({
+      next: (courses) => {
+        this.courses.set(courses);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load courses. Make sure your Moodle account is linked.');
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -105,6 +105,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Grades
         </a>
         <a
+          routerLink="/forums"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
+          Forums
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -116,6 +116,45 @@ public sealed class MoodleService(
         return result;
     }
 
+    public async Task<IReadOnlyList<MoodleForumDto>> GetForumsAsync(
+        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default)
+    {
+        string cacheKey = $"moodle:forums:{HashToken(moodleToken)}:{courseId}";
+
+        var cached = await GetFromCacheAsync<List<MoodleForumDto>>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, $"/mod_forum_get_forums_by_courses?courseids[0]={courseId}", cancellationToken);
+
+        var forums = JsonSerializer.Deserialize<List<MoodleForumDto>>(response, JsonOptions) ?? [];
+
+        await SetCacheAsync(cacheKey, forums, ContentCacheDuration, cancellationToken);
+
+        return forums;
+    }
+
+    public async Task<MoodleForumDiscussionsResponseDto> GetForumDiscussionsAsync(
+        string moodleUrl, string moodleToken, int forumId, CancellationToken cancellationToken = default)
+    {
+        string cacheKey = $"moodle:discussions:{HashToken(moodleToken)}:{forumId}";
+
+        var cached = await GetFromCacheAsync<MoodleForumDiscussionsResponseDto>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, $"/mod_forum_get_forum_discussions?forumid={forumId}", cancellationToken);
+
+        var result = JsonSerializer.Deserialize<MoodleForumDiscussionsResponseDto>(response, JsonOptions)
+            ?? new MoodleForumDiscussionsResponseDto();
+
+        await SetCacheAsync(cacheKey, result, ContentCacheDuration, cancellationToken);
+
+        return result;
+    }
+
     private async Task<string> SendMoodleRequestAsync(
         string moodleUrl, string moodleToken, string endpoint, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary
- Lazy-load forums and discussions from Moodle via `mod_forum_get_forums_by_courses` and `mod_forum_get_forum_discussions`
- Backend: Two new CQRS queries (`GetForumsQuery`, `GetForumDiscussionsQuery`) with caching, two new controller endpoints
- Frontend: Drill-down navigation (courses → forums → discussions) with back buttons, discussion cards showing author avatars/initials, pinned badges, reply counts, and HTML message previews

## Test plan
- [ ] Backend and frontend build with 0 warnings
- [ ] Link Moodle account, select a course, and verify forums load
- [ ] Select a forum and verify discussions load with correct ordering (pinned first)
- [ ] Verify back navigation between courses → forums → discussions
- [ ] Verify error state when Moodle is not linked

Closes #24