### PR TITLE
feat(timetable): add weekly timetable with Moodle calendar events

### DIFF
--- a/src/Kursa.API/Controllers/MoodleController.cs
+++ b/src/Kursa.API/Controllers/MoodleController.cs
@@ -104,4 +104,15 @@ public class MoodleController(ISender sender) : ControllerBase
             ? Ok(result.Value)
             : BadRequest(result.Error);
     }
+
+    [HttpGet("calendar")]
+    public async Task<IActionResult> GetCalendarEventsAsync(
+        [FromQuery] DateTime weekStart, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetCalendarEventsQuery(weekStart), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
 }

--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -25,4 +25,8 @@ public interface IMoodleService
 
     Task<MoodleForumDiscussionsResponseDto> GetForumDiscussionsAsync(
         string moodleUrl, string moodleToken, int forumId, CancellationToken cancellationToken = default);
+
+    Task<MoodleCalendarEventsResponseDto> GetCalendarEventsAsync(
+        string moodleUrl, string moodleToken, long timeStart, long timeEnd,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Moodle/Models/MoodleCalendarDtos.cs
+++ b/src/Kursa.Application/Features/Moodle/Models/MoodleCalendarDtos.cs
@@ -1,0 +1,61 @@
+using System.Text.Json.Serialization;
+
+namespace Kursa.Application.Features.Moodle.Models;
+
+/// <summary>
+/// Wrapper for core_calendar_get_calendar_events response.
+/// </summary>
+public sealed record MoodleCalendarEventsResponseDto
+{
+    [JsonPropertyName("events")]
+    public IReadOnlyList<MoodleCalendarEventDto> Events { get; init; } = [];
+}
+
+/// <summary>
+/// A single Moodle calendar event.
+/// </summary>
+public sealed record MoodleCalendarEventDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("courseid")]
+    public int CourseId { get; init; }
+
+    [JsonPropertyName("timestart")]
+    public long TimeStart { get; init; }
+
+    [JsonPropertyName("timeduration")]
+    public long TimeDuration { get; init; }
+
+    [JsonPropertyName("eventtype")]
+    public string EventType { get; init; } = string.Empty;
+
+    [JsonPropertyName("modulename")]
+    public string? ModuleName { get; init; }
+
+    [JsonPropertyName("instance")]
+    public int? Instance { get; init; }
+}
+
+/// <summary>
+/// Calendar event view for the frontend.
+/// </summary>
+public sealed record CalendarEventViewDto
+{
+    public int Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public int CourseId { get; init; }
+    public DateTime StartTime { get; init; }
+    public DateTime EndTime { get; init; }
+    public int DurationMinutes { get; init; }
+    public string EventType { get; init; } = string.Empty;
+    public string? ModuleName { get; init; }
+}

--- a/src/Kursa.Application/Features/Moodle/Queries/GetCalendarEvents.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetCalendarEvents.cs
@@ -1,0 +1,64 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Moodle.Queries;
+
+public sealed record GetCalendarEventsQuery(DateTime WeekStart) : IRequest<Result<IReadOnlyList<CalendarEventViewDto>>>;
+
+public sealed class GetCalendarEventsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<GetCalendarEventsQuery, Result<IReadOnlyList<CalendarEventViewDto>>>
+{
+    public async Task<Result<IReadOnlyList<CalendarEventViewDto>>> Handle(
+        GetCalendarEventsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<CalendarEventViewDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<CalendarEventViewDto>>.Failure("User not found.");
+
+        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+            return Result<IReadOnlyList<CalendarEventViewDto>>.Failure("Moodle account is not linked.");
+
+        DateTime weekEnd = request.WeekStart.AddDays(7);
+        long timeStart = new DateTimeOffset(request.WeekStart, TimeSpan.Zero).ToUnixTimeSeconds();
+        long timeEnd = new DateTimeOffset(weekEnd, TimeSpan.Zero).ToUnixTimeSeconds();
+
+        MoodleCalendarEventsResponseDto response = await moodleService.GetCalendarEventsAsync(
+            user.MoodleUrl, user.MoodleToken, timeStart, timeEnd, cancellationToken);
+
+        var events = response.Events
+            .Select(e =>
+            {
+                DateTime start = DateTimeOffset.FromUnixTimeSeconds(e.TimeStart).UtcDateTime;
+                int durationMinutes = (int)(e.TimeDuration / 60);
+                if (durationMinutes <= 0) durationMinutes = 60; // Default 1 hour
+
+                return new CalendarEventViewDto
+                {
+                    Id = e.Id,
+                    Title = e.Name,
+                    Description = e.Description,
+                    CourseId = e.CourseId,
+                    StartTime = start,
+                    EndTime = start.AddMinutes(durationMinutes),
+                    DurationMinutes = durationMinutes,
+                    EventType = e.EventType,
+                    ModuleName = e.ModuleName,
+                };
+            })
+            .OrderBy(e => e.StartTime)
+            .ToList();
+
+        return Result<IReadOnlyList<CalendarEventViewDto>>.Success(events);
+    }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -76,6 +76,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/forums/forums.component').then((m) => m.ForumsComponent),
       },
+      {
+        path: 'timetable',
+        loadComponent: () =>
+          import('./features/timetable/timetable.component').then((m) => m.TimetableComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/timetable.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/timetable.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface CalendarEventView {
+  id: number;
+  title: string;
+  description: string | null;
+  courseId: number;
+  startTime: string;
+  endTime: string;
+  durationMinutes: number;
+  eventType: string;
+  moduleName: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TimetableService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/moodle';
+
+  getCalendarEvents(weekStart: Date): Observable<CalendarEventView[]> {
+    const params = new HttpParams().set('weekStart', weekStart.toISOString());
+    return this.http.get<CalendarEventView[]>(`${this.baseUrl}/calendar`, { params });
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/timetable/timetable.component.ts
+++ b/src/Kursa.Frontend/src/app/features/timetable/timetable.component.ts
@@ -1,0 +1,273 @@
+import { ChangeDetectionStrategy, Component, signal, computed, inject, OnInit } from '@angular/core';
+import { TimetableService, CalendarEventView } from '../../core/services/timetable.service';
+
+@Component({
+  selector: 'app-timetable',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [],
+  template: `
+    <div class="mx-auto max-w-7xl space-y-6 p-6">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold text-foreground">Timetable</h1>
+          <p class="text-sm text-muted-foreground">Your weekly schedule</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            (click)="goToToday()"
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            (click)="previousWeek()"
+            aria-label="Previous week"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="m15 18-6-6 6-6" /></svg>
+          </button>
+          <span class="min-w-48 text-center text-sm font-medium text-foreground">{{ weekLabel() }}</span>
+          <button
+            type="button"
+            class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            (click)="nextWeek()"
+            aria-label="Next week"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="m9 18 6-6-6-6" /></svg>
+          </button>
+        </div>
+      </div>
+
+      @if (loading()) {
+        <div class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" role="status">
+            <span class="sr-only">Loading timetable...</span>
+          </div>
+        </div>
+      } @else if (error()) {
+        <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          {{ error() }}
+        </div>
+      } @else {
+        <!-- Weekly Grid -->
+        <div class="overflow-x-auto rounded-lg border border-border bg-card">
+          <div class="grid min-w-[800px] grid-cols-8">
+            <!-- Header row -->
+            <div class="border-b border-r border-border p-2"></div>
+            @for (day of weekDays(); track $index) {
+              <div
+                class="border-b border-r border-border p-2 text-center last:border-r-0"
+                [class.bg-primary/5]="day.isToday"
+              >
+                <div class="text-xs font-medium text-muted-foreground">{{ day.dayName }}</div>
+                <div
+                  class="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full text-sm"
+                  [class]="day.isToday ? 'bg-primary text-primary-foreground font-bold' : 'text-foreground'"
+                >
+                  {{ day.date.getDate() }}
+                </div>
+              </div>
+            }
+
+            <!-- Time slots -->
+            @for (hour of hours; track hour) {
+              <div class="border-b border-r border-border p-1 text-right text-xs text-muted-foreground">
+                {{ formatHour(hour) }}
+              </div>
+              @for (day of weekDays(); track $index) {
+                <div
+                  class="relative min-h-12 border-b border-r border-border last:border-r-0"
+                  [class.bg-primary/5]="day.isToday"
+                >
+                  @for (event of getEventsForSlot(day.date, hour); track event.id) {
+                    <div
+                      class="absolute inset-x-0.5 rounded px-1 py-0.5 text-xs"
+                      [class]="getEventColor(event.eventType)"
+                      [style.top.px]="getEventTopOffset(event)"
+                      [style.height.px]="getEventHeight(event)"
+                      [title]="event.title + ' (' + formatTime(event.startTime) + ' - ' + formatTime(event.endTime) + ')'"
+                    >
+                      <div class="truncate font-medium">{{ event.title }}</div>
+                      <div class="truncate opacity-75">{{ formatTime(event.startTime) }}</div>
+                    </div>
+                  }
+                </div>
+              }
+            }
+          </div>
+        </div>
+
+        <!-- Event List (below grid for quick reference) -->
+        @if (events().length > 0) {
+          <div>
+            <h2 class="mb-3 text-sm font-medium text-muted-foreground">This week's events ({{ events().length }})</h2>
+            <div class="space-y-2">
+              @for (event of events(); track event.id) {
+                <div class="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
+                  <div class="h-2 w-2 shrink-0 rounded-full" [class]="getEventDotColor(event.eventType)"></div>
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate text-sm font-medium text-foreground">{{ event.title }}</p>
+                    <p class="text-xs text-muted-foreground">
+                      {{ formatEventDate(event.startTime) }} — {{ formatTime(event.startTime) }} to {{ formatTime(event.endTime) }}
+                    </p>
+                  </div>
+                  <span class="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground capitalize">
+                    {{ event.eventType }}
+                  </span>
+                </div>
+              }
+            </div>
+          </div>
+        } @else {
+          <div class="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            No events this week.
+          </div>
+        }
+      }
+    </div>
+  `,
+})
+export class TimetableComponent implements OnInit {
+  private readonly timetableService = inject(TimetableService);
+
+  readonly events = signal<CalendarEventView[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly weekStart = signal(TimetableComponent.getMonday(new Date()));
+
+  readonly hours = Array.from({ length: 14 }, (_, i) => i + 7); // 07:00 - 20:00
+
+  readonly weekLabel = computed(() => {
+    const start = this.weekStart();
+    const end = new Date(start);
+    end.setDate(end.getDate() + 6);
+    const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
+    return `${start.toLocaleDateString('default', opts)} — ${end.toLocaleDateString('default', { ...opts, year: 'numeric' })}`;
+  });
+
+  readonly weekDays = computed(() => {
+    const start = this.weekStart();
+    const today = new Date();
+    const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+    return Array.from({ length: 7 }, (_, i) => {
+      const date = new Date(start);
+      date.setDate(date.getDate() + i);
+      return {
+        dayName: dayNames[i],
+        date,
+        isToday:
+          date.getDate() === today.getDate() &&
+          date.getMonth() === today.getMonth() &&
+          date.getFullYear() === today.getFullYear(),
+      };
+    });
+  });
+
+  ngOnInit(): void {
+    this.loadEvents();
+  }
+
+  previousWeek(): void {
+    const current = this.weekStart();
+    const prev = new Date(current);
+    prev.setDate(prev.getDate() - 7);
+    this.weekStart.set(prev);
+    this.loadEvents();
+  }
+
+  nextWeek(): void {
+    const current = this.weekStart();
+    const next = new Date(current);
+    next.setDate(next.getDate() + 7);
+    this.weekStart.set(next);
+    this.loadEvents();
+  }
+
+  goToToday(): void {
+    this.weekStart.set(TimetableComponent.getMonday(new Date()));
+    this.loadEvents();
+  }
+
+  getEventsForSlot(date: Date, hour: number): CalendarEventView[] {
+    return this.events().filter(e => {
+      const start = new Date(e.startTime);
+      return (
+        start.getDate() === date.getDate() &&
+        start.getMonth() === date.getMonth() &&
+        start.getFullYear() === date.getFullYear() &&
+        start.getHours() === hour
+      );
+    });
+  }
+
+  getEventTopOffset(event: CalendarEventView): number {
+    const start = new Date(event.startTime);
+    return (start.getMinutes() / 60) * 48; // 48px per hour slot
+  }
+
+  getEventHeight(event: CalendarEventView): number {
+    return Math.max(20, (event.durationMinutes / 60) * 48);
+  }
+
+  getEventColor(type: string): string {
+    switch (type) {
+      case 'course': return 'bg-blue-500/20 text-blue-400 border-l-2 border-blue-500';
+      case 'due': return 'bg-red-500/20 text-red-400 border-l-2 border-red-500';
+      case 'user': return 'bg-green-500/20 text-green-400 border-l-2 border-green-500';
+      case 'site': return 'bg-purple-500/20 text-purple-400 border-l-2 border-purple-500';
+      default: return 'bg-primary/20 text-primary border-l-2 border-primary';
+    }
+  }
+
+  getEventDotColor(type: string): string {
+    switch (type) {
+      case 'course': return 'bg-blue-500';
+      case 'due': return 'bg-red-500';
+      case 'user': return 'bg-green-500';
+      case 'site': return 'bg-purple-500';
+      default: return 'bg-primary';
+    }
+  }
+
+  formatHour(hour: number): string {
+    return `${hour.toString().padStart(2, '0')}:00`;
+  }
+
+  formatTime(dateStr: string): string {
+    const date = new Date(dateStr);
+    return date.toLocaleTimeString('default', { hour: '2-digit', minute: '2-digit' });
+  }
+
+  formatEventDate(dateStr: string): string {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('default', { weekday: 'short', month: 'short', day: 'numeric' });
+  }
+
+  private loadEvents(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.timetableService.getCalendarEvents(this.weekStart()).subscribe({
+      next: (events) => {
+        this.events.set(events);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load timetable. Make sure your Moodle account is linked.');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  private static getMonday(date: Date): Date {
+    const d = new Date(date);
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+    d.setDate(diff);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -113,6 +113,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Forums
         </a>
         <a
+          routerLink="/timetable"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><rect width="18" height="18" x="3" y="4" rx="2" ry="2" /><line x1="16" x2="16" y1="2" y2="6" /><line x1="8" x2="8" y1="2" y2="6" /><line x1="3" x2="21" y1="10" y2="10" /></svg>
+          Timetable
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -155,6 +155,29 @@ public sealed class MoodleService(
         return result;
     }
 
+    public async Task<MoodleCalendarEventsResponseDto> GetCalendarEventsAsync(
+        string moodleUrl, string moodleToken, long timeStart, long timeEnd,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = $"moodle:calendar:{HashToken(moodleToken)}:{timeStart}:{timeEnd}";
+
+        var cached = await GetFromCacheAsync<MoodleCalendarEventsResponseDto>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        string endpoint = $"/core_calendar_get_calendar_events?events[timestart]={timeStart}&events[timeend]={timeEnd}";
+
+        var response = await SendMoodleRequestAsync(
+            moodleUrl, moodleToken, endpoint, cancellationToken);
+
+        var result = JsonSerializer.Deserialize<MoodleCalendarEventsResponseDto>(response, JsonOptions)
+            ?? new MoodleCalendarEventsResponseDto();
+
+        await SetCacheAsync(cacheKey, result, ContentCacheDuration, cancellationToken);
+
+        return result;
+    }
+
     private async Task<string> SendMoodleRequestAsync(
         string moodleUrl, string moodleToken, string endpoint, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary
- Lazy-load calendar events from Moodle via `core_calendar_get_calendar_events` with week-based time ranges
- Backend: `GetCalendarEventsQuery` converts Unix timestamps to `CalendarEventViewDto`, defaults 1-hour duration for events without duration
- Frontend: Weekly grid view (07:00-20:00, Mon-Sun) with color-coded event types (course/due/user/site), today column highlight, week navigation (prev/next/today), and event list summary below the grid

## Test plan
- [ ] Backend and frontend build with 0 warnings
- [ ] Link Moodle account and verify calendar events load
- [ ] Test week navigation (previous, next, today)
- [ ] Verify events appear in correct time slots on the grid
- [ ] Verify today column is highlighted

Closes #25