### PR TITLE
feat(microsoft): integrate OneNote and SharePoint via Microsoft Graph API

### DIFF
--- a/src/Kursa.API/Controllers/GraphController.cs
+++ b/src/Kursa.API/Controllers/GraphController.cs
@@ -1,0 +1,94 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Features.Graph.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+/// <summary>
+/// Microsoft Graph integration for OneNote and SharePoint.
+/// Expects a Microsoft Graph access token in the X-Graph-Token header.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class GraphController(IMicrosoftGraphService graphService) : ControllerBase
+{
+    // -- OneNote --
+
+    [HttpGet("onenote/notebooks")]
+    public async Task<IActionResult> GetNotebooksAsync(CancellationToken cancellationToken)
+    {
+        string? token = GetGraphToken();
+        if (token is null)
+            return BadRequest("Microsoft Graph token is required. Set the X-Graph-Token header.");
+
+        IReadOnlyList<OneNoteNotebookDto> notebooks = await graphService.GetNotebooksAsync(token, cancellationToken);
+        return Ok(notebooks);
+    }
+
+    [HttpGet("onenote/notebooks/{notebookId}/sections")]
+    public async Task<IActionResult> GetSectionsAsync(string notebookId, CancellationToken cancellationToken)
+    {
+        string? token = GetGraphToken();
+        if (token is null)
+            return BadRequest("Microsoft Graph token is required. Set the X-Graph-Token header.");
+
+        IReadOnlyList<OneNoteSectionDto> sections = await graphService.GetSectionsAsync(token, notebookId, cancellationToken);
+        return Ok(sections);
+    }
+
+    [HttpGet("onenote/sections/{sectionId}/pages")]
+    public async Task<IActionResult> GetPagesAsync(string sectionId, CancellationToken cancellationToken)
+    {
+        string? token = GetGraphToken();
+        if (token is null)
+            return BadRequest("Microsoft Graph token is required. Set the X-Graph-Token header.");
+
+        IReadOnlyList<OneNotePageDto> pages = await graphService.GetPagesAsync(token, sectionId, cancellationToken);
+        return Ok(pages);
+    }
+
+    [HttpGet("onenote/pages/{pageId}/content")]
+    public async Task<IActionResult> GetPageContentAsync(string pageId, CancellationToken cancellationToken)
+    {
+        string? token = GetGraphToken();
+        if (token is null)
+            return BadRequest("Microsoft Graph token is required. Set the X-Graph-Token header.");
+
+        string content = await graphService.GetPageContentAsync(token, pageId, cancellationToken);
+        return Content(content, "text/html");
+    }
+
+    // -- SharePoint --
+
+    [HttpGet("sharepoint/sites")]
+    public async Task<IActionResult> GetSitesAsync(
+        [FromQuery] string? search, CancellationToken cancellationToken)
+    {
+        string? token = GetGraphToken();
+        if (token is null)
+            return BadRequest("Microsoft Graph token is required. Set the X-Graph-Token header.");
+
+        IReadOnlyList<SharePointSiteDto> sites = await graphService.GetSitesAsync(token, search, cancellationToken);
+        return Ok(sites);
+    }
+
+    [HttpGet("sharepoint/sites/{siteId}/items")]
+    public async Task<IActionResult> GetDriveItemsAsync(
+        string siteId, [FromQuery] string? folderId, CancellationToken cancellationToken)
+    {
+        string? token = GetGraphToken();
+        if (token is null)
+            return BadRequest("Microsoft Graph token is required. Set the X-Graph-Token header.");
+
+        IReadOnlyList<SharePointDriveItemDto> items = await graphService.GetDriveItemsAsync(
+            token, siteId, folderId, cancellationToken);
+        return Ok(items);
+    }
+
+    private string? GetGraphToken()
+    {
+        return Request.Headers["X-Graph-Token"].FirstOrDefault();
+    }
+}

--- a/src/Kursa.Application/Common/Interfaces/IMicrosoftGraphService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMicrosoftGraphService.cs
@@ -1,0 +1,25 @@
+using Kursa.Application.Features.Graph.Models;
+
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IMicrosoftGraphService
+{
+    Task<IReadOnlyList<OneNoteNotebookDto>> GetNotebooksAsync(
+        string accessToken, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<OneNoteSectionDto>> GetSectionsAsync(
+        string accessToken, string notebookId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<OneNotePageDto>> GetPagesAsync(
+        string accessToken, string sectionId, CancellationToken cancellationToken = default);
+
+    Task<string> GetPageContentAsync(
+        string accessToken, string pageId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SharePointSiteDto>> GetSitesAsync(
+        string accessToken, string? searchQuery = null, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SharePointDriveItemDto>> GetDriveItemsAsync(
+        string accessToken, string siteId, string? folderId = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Features/Graph/Models/GraphDtos.cs
+++ b/src/Kursa.Application/Features/Graph/Models/GraphDtos.cs
@@ -1,0 +1,136 @@
+using System.Text.Json.Serialization;
+
+namespace Kursa.Application.Features.Graph.Models;
+
+// -- OneNote DTOs --
+
+public sealed record OneNoteNotebookDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; init; } = string.Empty;
+
+    [JsonPropertyName("createdDateTime")]
+    public DateTime? CreatedAt { get; init; }
+
+    [JsonPropertyName("lastModifiedDateTime")]
+    public DateTime? LastModifiedAt { get; init; }
+}
+
+public sealed record OneNoteSectionDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; init; } = string.Empty;
+
+    [JsonPropertyName("createdDateTime")]
+    public DateTime? CreatedAt { get; init; }
+
+    [JsonPropertyName("lastModifiedDateTime")]
+    public DateTime? LastModifiedAt { get; init; }
+}
+
+public sealed record OneNotePageDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("createdDateTime")]
+    public DateTime? CreatedAt { get; init; }
+
+    [JsonPropertyName("lastModifiedDateTime")]
+    public DateTime? LastModifiedAt { get; init; }
+
+    [JsonPropertyName("contentUrl")]
+    public string? ContentUrl { get; init; }
+}
+
+// -- SharePoint DTOs --
+
+public sealed record SharePointSiteDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; init; } = string.Empty;
+
+    [JsonPropertyName("webUrl")]
+    public string? WebUrl { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+}
+
+public sealed record SharePointDriveItemDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("webUrl")]
+    public string? WebUrl { get; init; }
+
+    [JsonPropertyName("size")]
+    public long Size { get; init; }
+
+    [JsonPropertyName("lastModifiedDateTime")]
+    public DateTime? LastModifiedAt { get; init; }
+
+    public bool IsFolder { get; init; }
+
+    public string? MimeType { get; init; }
+}
+
+// -- Graph API wrapper DTOs for deserialization --
+
+public sealed record GraphCollectionResponse<T>
+{
+    [JsonPropertyName("value")]
+    public IReadOnlyList<T> Value { get; init; } = [];
+}
+
+public sealed record GraphDriveItemRaw
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("webUrl")]
+    public string? WebUrl { get; init; }
+
+    [JsonPropertyName("size")]
+    public long Size { get; init; }
+
+    [JsonPropertyName("lastModifiedDateTime")]
+    public DateTime? LastModifiedDateTime { get; init; }
+
+    [JsonPropertyName("folder")]
+    public GraphFolderFacet? Folder { get; init; }
+
+    [JsonPropertyName("file")]
+    public GraphFileFacet? File { get; init; }
+}
+
+public sealed record GraphFolderFacet
+{
+    [JsonPropertyName("childCount")]
+    public int ChildCount { get; init; }
+}
+
+public sealed record GraphFileFacet
+{
+    [JsonPropertyName("mimeType")]
+    public string? MimeType { get; init; }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -81,6 +81,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/timetable/timetable.component').then((m) => m.TimetableComponent),
       },
+      {
+        path: 'microsoft',
+        loadComponent: () =>
+          import('./features/microsoft/microsoft.component').then((m) => m.MicrosoftComponent),
+      },
     ],
   },
 ];

--- a/src/Kursa.Frontend/src/app/core/services/graph.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/graph.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface OneNoteNotebook {
+  id: string;
+  displayName: string;
+  createdAt: string | null;
+  lastModifiedAt: string | null;
+}
+
+export interface OneNoteSection {
+  id: string;
+  displayName: string;
+  createdAt: string | null;
+  lastModifiedAt: string | null;
+}
+
+export interface OneNotePage {
+  id: string;
+  title: string;
+  createdAt: string | null;
+  lastModifiedAt: string | null;
+  contentUrl: string | null;
+}
+
+export interface SharePointSite {
+  id: string;
+  displayName: string;
+  webUrl: string | null;
+  description: string | null;
+}
+
+export interface SharePointDriveItem {
+  id: string;
+  name: string;
+  webUrl: string | null;
+  size: number;
+  lastModifiedAt: string | null;
+  isFolder: boolean;
+  mimeType: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class GraphService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/graph';
+
+  private graphToken: string | null = null;
+
+  setToken(token: string): void {
+    this.graphToken = token;
+  }
+
+  clearToken(): void {
+    this.graphToken = null;
+  }
+
+  hasToken(): boolean {
+    return this.graphToken !== null;
+  }
+
+  // -- OneNote --
+
+  getNotebooks(): Observable<OneNoteNotebook[]> {
+    return this.http.get<OneNoteNotebook[]>(
+      `${this.baseUrl}/onenote/notebooks`,
+      { headers: this.getHeaders() }
+    );
+  }
+
+  getSections(notebookId: string): Observable<OneNoteSection[]> {
+    return this.http.get<OneNoteSection[]>(
+      `${this.baseUrl}/onenote/notebooks/${notebookId}/sections`,
+      { headers: this.getHeaders() }
+    );
+  }
+
+  getPages(sectionId: string): Observable<OneNotePage[]> {
+    return this.http.get<OneNotePage[]>(
+      `${this.baseUrl}/onenote/sections/${sectionId}/pages`,
+      { headers: this.getHeaders() }
+    );
+  }
+
+  getPageContent(pageId: string): Observable<string> {
+    return this.http.get(
+      `${this.baseUrl}/onenote/pages/${pageId}/content`,
+      { headers: this.getHeaders(), responseType: 'text' }
+    );
+  }
+
+  // -- SharePoint --
+
+  getSites(search?: string): Observable<SharePointSite[]> {
+    let params = new HttpParams();
+    if (search) {
+      params = params.set('search', search);
+    }
+    return this.http.get<SharePointSite[]>(
+      `${this.baseUrl}/sharepoint/sites`,
+      { headers: this.getHeaders(), params }
+    );
+  }
+
+  getDriveItems(siteId: string, folderId?: string): Observable<SharePointDriveItem[]> {
+    let params = new HttpParams();
+    if (folderId) {
+      params = params.set('folderId', folderId);
+    }
+    return this.http.get<SharePointDriveItem[]>(
+      `${this.baseUrl}/sharepoint/sites/${siteId}/items`,
+      { headers: this.getHeaders(), params }
+    );
+  }
+
+  private getHeaders(): HttpHeaders {
+    let headers = new HttpHeaders();
+    if (this.graphToken) {
+      headers = headers.set('X-Graph-Token', this.graphToken);
+    }
+    return headers;
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/microsoft/microsoft.component.ts
+++ b/src/Kursa.Frontend/src/app/features/microsoft/microsoft.component.ts
@@ -1,0 +1,431 @@
+import { ChangeDetectionStrategy, Component, signal, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  GraphService,
+  OneNoteNotebook,
+  OneNoteSection,
+  OneNotePage,
+  SharePointSite,
+  SharePointDriveItem,
+} from '../../core/services/graph.service';
+
+type ActiveTab = 'onenote' | 'sharepoint';
+type OneNoteView = 'notebooks' | 'sections' | 'pages' | 'content';
+type SharePointView = 'sites' | 'items';
+
+@Component({
+  selector: 'app-microsoft',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule],
+  template: `
+    <div class="mx-auto max-w-7xl space-y-6 p-6">
+      <div>
+        <h1 class="text-2xl font-bold text-foreground">Microsoft Integration</h1>
+        <p class="text-sm text-muted-foreground">Access OneNote notebooks and SharePoint files</p>
+      </div>
+
+      <!-- Token input -->
+      @if (!hasToken()) {
+        <div class="rounded-lg border border-border bg-card p-6">
+          <h2 class="mb-2 font-medium text-foreground">Connect Microsoft Account</h2>
+          <p class="mb-4 text-sm text-muted-foreground">
+            Enter your Microsoft Graph access token to browse OneNote and SharePoint content.
+          </p>
+          <div class="flex gap-2">
+            <input
+              type="password"
+              class="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              placeholder="Microsoft Graph access token"
+              [(ngModel)]="tokenInput"
+              (keydown.enter)="connectToken()"
+            />
+            <button
+              type="button"
+              class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              (click)="connectToken()"
+            >
+              Connect
+            </button>
+          </div>
+        </div>
+      } @else {
+        <!-- Tab bar -->
+        <div class="flex items-center justify-between">
+          <div class="flex gap-2 rounded-lg border border-border bg-card p-1">
+            <button
+              type="button"
+              class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+              [class]="activeTab() === 'onenote' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'"
+              (click)="switchTab('onenote')"
+            >
+              OneNote
+            </button>
+            <button
+              type="button"
+              class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+              [class]="activeTab() === 'sharepoint' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'"
+              (click)="switchTab('sharepoint')"
+            >
+              SharePoint
+            </button>
+          </div>
+          <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            (click)="disconnect()"
+          >
+            Disconnect
+          </button>
+        </div>
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-12">
+            <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" role="status">
+              <span class="sr-only">Loading...</span>
+            </div>
+          </div>
+        } @else if (error()) {
+          <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+            {{ error() }}
+          </div>
+        } @else if (activeTab() === 'onenote') {
+          <!-- OneNote -->
+          @if (onenoteView() !== 'notebooks') {
+            <button
+              type="button"
+              class="flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+              (click)="onenoteBack()"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="m15 18-6-6 6-6" /></svg>
+              Back
+            </button>
+          }
+
+          @if (onenoteView() === 'notebooks') {
+            @if (notebooks().length === 0) {
+              <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">No notebooks found.</div>
+            } @else {
+              <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                @for (nb of notebooks(); track nb.id) {
+                  <button
+                    type="button"
+                    class="rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-accent/50"
+                    (click)="openNotebook(nb)"
+                  >
+                    <div class="flex items-center gap-3">
+                      <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-500/10 text-purple-500">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" /><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" /></svg>
+                      </div>
+                      <div class="min-w-0 flex-1">
+                        <h3 class="truncate font-medium text-foreground">{{ nb.displayName }}</h3>
+                        @if (nb.lastModifiedAt) {
+                          <p class="text-xs text-muted-foreground">{{ formatDate(nb.lastModifiedAt) }}</p>
+                        }
+                      </div>
+                    </div>
+                  </button>
+                }
+              </div>
+            }
+          } @else if (onenoteView() === 'sections') {
+            <h2 class="text-lg font-semibold text-foreground">{{ currentNotebookName() }}</h2>
+            @if (sections().length === 0) {
+              <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">No sections found.</div>
+            } @else {
+              <div class="space-y-2">
+                @for (sec of sections(); track sec.id) {
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-3 rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent/50"
+                    (click)="openSection(sec)"
+                  >
+                    <div class="flex h-8 w-8 items-center justify-center rounded bg-blue-500/10 text-blue-500 text-sm font-medium">S</div>
+                    <span class="text-foreground">{{ sec.displayName }}</span>
+                  </button>
+                }
+              </div>
+            }
+          } @else if (onenoteView() === 'pages') {
+            <h2 class="text-lg font-semibold text-foreground">{{ currentSectionName() }}</h2>
+            @if (pages().length === 0) {
+              <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">No pages found.</div>
+            } @else {
+              <div class="space-y-2">
+                @for (page of pages(); track page.id) {
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-3 rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent/50"
+                    (click)="openPage(page)"
+                  >
+                    <div class="flex h-8 w-8 items-center justify-center rounded bg-green-500/10 text-green-500 text-sm font-medium">P</div>
+                    <div class="min-w-0 flex-1">
+                      <span class="text-foreground">{{ page.title }}</span>
+                      @if (page.lastModifiedAt) {
+                        <p class="text-xs text-muted-foreground">{{ formatDate(page.lastModifiedAt) }}</p>
+                      }
+                    </div>
+                  </button>
+                }
+              </div>
+            }
+          } @else if (onenoteView() === 'content') {
+            <div class="rounded-lg border border-border bg-card p-6">
+              <div class="prose prose-invert max-w-none" [innerHTML]="pageContent()"></div>
+            </div>
+          }
+        } @else {
+          <!-- SharePoint -->
+          @if (sharepointView() === 'sites') {
+            @if (sites().length === 0) {
+              <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">No SharePoint sites found.</div>
+            } @else {
+              <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                @for (site of sites(); track site.id) {
+                  <button
+                    type="button"
+                    class="rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-accent/50"
+                    (click)="openSite(site)"
+                  >
+                    <div class="flex items-center gap-3">
+                      <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-blue-500">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" /></svg>
+                      </div>
+                      <div class="min-w-0 flex-1">
+                        <h3 class="truncate font-medium text-foreground">{{ site.displayName }}</h3>
+                        @if (site.description) {
+                          <p class="truncate text-xs text-muted-foreground">{{ site.description }}</p>
+                        }
+                      </div>
+                    </div>
+                  </button>
+                }
+              </div>
+            }
+          } @else {
+            <button
+              type="button"
+              class="flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+              (click)="sharepointBack()"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="m15 18-6-6 6-6" /></svg>
+              Back
+            </button>
+            <h2 class="text-lg font-semibold text-foreground">{{ currentSiteName() }}</h2>
+            @if (driveItems().length === 0) {
+              <div class="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">No files found.</div>
+            } @else {
+              <div class="space-y-2">
+                @for (item of driveItems(); track item.id) {
+                  @if (item.isFolder) {
+                    <button
+                      type="button"
+                      class="flex w-full items-center gap-3 rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent/50"
+                      (click)="openFolder(item.id)"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5 text-yellow-500" aria-hidden="true"><path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" /></svg>
+                      <span class="text-foreground">{{ item.name }}</span>
+                    </button>
+                  } @else {
+                    <a
+                      [href]="item.webUrl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent/50"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5 text-muted-foreground" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /></svg>
+                      <div class="min-w-0 flex-1">
+                        <span class="text-foreground">{{ item.name }}</span>
+                        <p class="text-xs text-muted-foreground">{{ formatFileSize(item.size) }}</p>
+                      </div>
+                    </a>
+                  }
+                }
+              </div>
+            }
+          }
+        }
+      }
+    </div>
+  `,
+})
+export class MicrosoftComponent implements OnInit {
+  private readonly graphService = inject(GraphService);
+
+  tokenInput = '';
+  readonly activeTab = signal<ActiveTab>('onenote');
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+
+  // OneNote state
+  readonly onenoteView = signal<OneNoteView>('notebooks');
+  readonly notebooks = signal<OneNoteNotebook[]>([]);
+  readonly sections = signal<OneNoteSection[]>([]);
+  readonly pages = signal<OneNotePage[]>([]);
+  readonly pageContent = signal('');
+  readonly currentNotebookName = signal('');
+  readonly currentSectionName = signal('');
+
+  // SharePoint state
+  readonly sharepointView = signal<SharePointView>('sites');
+  readonly sites = signal<SharePointSite[]>([]);
+  readonly driveItems = signal<SharePointDriveItem[]>([]);
+  readonly currentSiteName = signal('');
+  private currentSiteId = '';
+
+  ngOnInit(): void {
+    // Check if already connected
+  }
+
+  hasToken(): boolean {
+    return this.graphService.hasToken();
+  }
+
+  connectToken(): void {
+    if (!this.tokenInput.trim()) return;
+    this.graphService.setToken(this.tokenInput.trim());
+    this.tokenInput = '';
+    this.loadInitialData();
+  }
+
+  disconnect(): void {
+    this.graphService.clearToken();
+    this.notebooks.set([]);
+    this.sites.set([]);
+  }
+
+  switchTab(tab: ActiveTab): void {
+    this.activeTab.set(tab);
+    this.error.set(null);
+    if (tab === 'onenote' && this.notebooks().length === 0) {
+      this.loadNotebooks();
+    } else if (tab === 'sharepoint' && this.sites().length === 0) {
+      this.loadSites();
+    }
+  }
+
+  // -- OneNote navigation --
+
+  openNotebook(nb: OneNoteNotebook): void {
+    this.currentNotebookName.set(nb.displayName);
+    this.loading.set(true);
+    this.graphService.getSections(nb.id).subscribe({
+      next: (sections) => {
+        this.sections.set(sections);
+        this.onenoteView.set('sections');
+        this.loading.set(false);
+      },
+      error: () => this.handleError('Failed to load sections.'),
+    });
+  }
+
+  openSection(sec: OneNoteSection): void {
+    this.currentSectionName.set(sec.displayName);
+    this.loading.set(true);
+    this.graphService.getPages(sec.id).subscribe({
+      next: (pages) => {
+        this.pages.set(pages);
+        this.onenoteView.set('pages');
+        this.loading.set(false);
+      },
+      error: () => this.handleError('Failed to load pages.'),
+    });
+  }
+
+  openPage(page: OneNotePage): void {
+    this.loading.set(true);
+    this.graphService.getPageContent(page.id).subscribe({
+      next: (content) => {
+        this.pageContent.set(content);
+        this.onenoteView.set('content');
+        this.loading.set(false);
+      },
+      error: () => this.handleError('Failed to load page content.'),
+    });
+  }
+
+  onenoteBack(): void {
+    this.error.set(null);
+    switch (this.onenoteView()) {
+      case 'sections': this.onenoteView.set('notebooks'); break;
+      case 'pages': this.onenoteView.set('sections'); break;
+      case 'content': this.onenoteView.set('pages'); break;
+    }
+  }
+
+  // -- SharePoint navigation --
+
+  openSite(site: SharePointSite): void {
+    this.currentSiteId = site.id;
+    this.currentSiteName.set(site.displayName);
+    this.loading.set(true);
+    this.graphService.getDriveItems(site.id).subscribe({
+      next: (items) => {
+        this.driveItems.set(items);
+        this.sharepointView.set('items');
+        this.loading.set(false);
+      },
+      error: () => this.handleError('Failed to load files.'),
+    });
+  }
+
+  openFolder(folderId: string): void {
+    this.loading.set(true);
+    this.graphService.getDriveItems(this.currentSiteId, folderId).subscribe({
+      next: (items) => {
+        this.driveItems.set(items);
+        this.loading.set(false);
+      },
+      error: () => this.handleError('Failed to load folder contents.'),
+    });
+  }
+
+  sharepointBack(): void {
+    this.error.set(null);
+    this.sharepointView.set('sites');
+    this.driveItems.set([]);
+  }
+
+  formatDate(dateStr: string): string {
+    return new Date(dateStr).toLocaleDateString('default', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  formatFileSize(bytes: number): string {
+    if (bytes === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+  }
+
+  private loadInitialData(): void {
+    this.loadNotebooks();
+    this.loadSites();
+  }
+
+  private loadNotebooks(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.graphService.getNotebooks().subscribe({
+      next: (notebooks) => {
+        this.notebooks.set(notebooks);
+        this.loading.set(false);
+      },
+      error: () => this.handleError('Failed to load notebooks.'),
+    });
+  }
+
+  private loadSites(): void {
+    this.graphService.getSites().subscribe({
+      next: (sites) => this.sites.set(sites),
+      error: () => { /* silent for background load */ },
+    });
+  }
+
+  private handleError(message: string): void {
+    this.error.set(message);
+    this.loading.set(false);
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/sidebar.component.ts
@@ -121,6 +121,14 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
           Timetable
         </a>
         <a
+          routerLink="/microsoft"
+          routerLinkActive="bg-accent text-accent-foreground"
+          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><rect width="20" height="14" x="2" y="3" rx="2" /><line x1="8" x2="8" y1="21" y2="17" /><line x1="16" x2="16" y1="21" y2="17" /><line x1="12" x2="12" y1="21" y2="17" /></svg>
+          Microsoft
+        </a>
+        <a
           routerLink="/settings"
           routerLinkActive="bg-accent text-accent-foreground"
           class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -76,6 +76,10 @@ public static class DependencyInjection
         // Recording indexing (transcript → embeddings + summary)
         services.AddScoped<IRecordingIndexingService, RecordingIndexingService>();
 
+        // Microsoft Graph (OneNote + SharePoint)
+        services.AddHttpClient("MicrosoftGraph");
+        services.AddScoped<IMicrosoftGraphService, MicrosoftGraphService>();
+
         // Whisper transcription
         services.AddHttpClient("Whisper");
         services.AddScoped<ITranscriptionService, WhisperTranscriptionService>();

--- a/src/Kursa.Infrastructure/Services/MicrosoftGraphService.cs
+++ b/src/Kursa.Infrastructure/Services/MicrosoftGraphService.cs
@@ -1,0 +1,110 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Features.Graph.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class MicrosoftGraphService(
+    IHttpClientFactory httpClientFactory,
+    ILogger<MicrosoftGraphService> logger) : IMicrosoftGraphService
+{
+    private const string GraphBaseUrl = "https://graph.microsoft.com/v1.0";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public async Task<IReadOnlyList<OneNoteNotebookDto>> GetNotebooksAsync(
+        string accessToken, CancellationToken cancellationToken = default)
+    {
+        string json = await SendGraphRequestAsync(accessToken, "/me/onenote/notebooks", cancellationToken);
+        var response = JsonSerializer.Deserialize<GraphCollectionResponse<OneNoteNotebookDto>>(json, JsonOptions);
+        return response?.Value ?? [];
+    }
+
+    public async Task<IReadOnlyList<OneNoteSectionDto>> GetSectionsAsync(
+        string accessToken, string notebookId, CancellationToken cancellationToken = default)
+    {
+        string json = await SendGraphRequestAsync(
+            accessToken, $"/me/onenote/notebooks/{notebookId}/sections", cancellationToken);
+        var response = JsonSerializer.Deserialize<GraphCollectionResponse<OneNoteSectionDto>>(json, JsonOptions);
+        return response?.Value ?? [];
+    }
+
+    public async Task<IReadOnlyList<OneNotePageDto>> GetPagesAsync(
+        string accessToken, string sectionId, CancellationToken cancellationToken = default)
+    {
+        string json = await SendGraphRequestAsync(
+            accessToken, $"/me/onenote/sections/{sectionId}/pages", cancellationToken);
+        var response = JsonSerializer.Deserialize<GraphCollectionResponse<OneNotePageDto>>(json, JsonOptions);
+        return response?.Value ?? [];
+    }
+
+    public async Task<string> GetPageContentAsync(
+        string accessToken, string pageId, CancellationToken cancellationToken = default)
+    {
+        return await SendGraphRequestAsync(
+            accessToken, $"/me/onenote/pages/{pageId}/content", cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SharePointSiteDto>> GetSitesAsync(
+        string accessToken, string? searchQuery = null, CancellationToken cancellationToken = default)
+    {
+        string endpoint = string.IsNullOrWhiteSpace(searchQuery)
+            ? "/sites?search=*"
+            : $"/sites?search={Uri.EscapeDataString(searchQuery)}";
+
+        string json = await SendGraphRequestAsync(accessToken, endpoint, cancellationToken);
+        var response = JsonSerializer.Deserialize<GraphCollectionResponse<SharePointSiteDto>>(json, JsonOptions);
+        return response?.Value ?? [];
+    }
+
+    public async Task<IReadOnlyList<SharePointDriveItemDto>> GetDriveItemsAsync(
+        string accessToken, string siteId, string? folderId = null,
+        CancellationToken cancellationToken = default)
+    {
+        string endpoint = string.IsNullOrEmpty(folderId)
+            ? $"/sites/{siteId}/drive/root/children"
+            : $"/sites/{siteId}/drive/items/{folderId}/children";
+
+        string json = await SendGraphRequestAsync(accessToken, endpoint, cancellationToken);
+        var response = JsonSerializer.Deserialize<GraphCollectionResponse<GraphDriveItemRaw>>(json, JsonOptions);
+
+        return response?.Value.Select(item => new SharePointDriveItemDto
+        {
+            Id = item.Id,
+            Name = item.Name,
+            WebUrl = item.WebUrl,
+            Size = item.Size,
+            LastModifiedAt = item.LastModifiedDateTime,
+            IsFolder = item.Folder is not null,
+            MimeType = item.File?.MimeType,
+        }).ToList() ?? [];
+    }
+
+    private async Task<string> SendGraphRequestAsync(
+        string accessToken, string endpoint, CancellationToken cancellationToken)
+    {
+        using HttpClient client = httpClientFactory.CreateClient("MicrosoftGraph");
+        client.BaseAddress = new Uri(GraphBaseUrl);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        logger.LogDebug("Calling Microsoft Graph: {Endpoint}", endpoint);
+
+        using HttpResponseMessage response = await client.GetAsync(endpoint, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            string body = await response.Content.ReadAsStringAsync(cancellationToken);
+            logger.LogError("Graph API error {StatusCode} for {Endpoint}: {Body}",
+                (int)response.StatusCode, endpoint, body);
+            throw new HttpRequestException(
+                $"Microsoft Graph API returned {(int)response.StatusCode}: {response.ReasonPhrase}");
+        }
+
+        return await response.Content.ReadAsStringAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- Backend: `IMicrosoftGraphService` with 6 methods for OneNote (notebooks, sections, pages, page content) and SharePoint (sites, drive items) via Microsoft Graph API v1.0
- `GraphController` with `X-Graph-Token` header-based authentication for delegated Graph access tokens
- Frontend: `MicrosoftComponent` with token connection flow, OneNote/SharePoint tab switching, drill-down browsing for both notebooks and SharePoint sites, folder navigation, file size display, and external file links

## Test plan
- [ ] Backend and frontend build with 0 warnings
- [ ] Token input form renders when not connected
- [ ] After entering token, OneNote tab loads notebooks
- [ ] Drill-down works: notebooks → sections → pages → HTML content
- [ ] SharePoint tab lists sites, clicking opens drive items
- [ ] Folder navigation works in SharePoint
- [ ] Disconnect clears token and returns to input form

Closes #26