### PR TITLE
feat(suggestions): add agentic AI study suggestions

### DIFF
--- a/src/Kursa.API/Controllers/SuggestionsController.cs
+++ b/src/Kursa.API/Controllers/SuggestionsController.cs
@@ -1,0 +1,22 @@
+using Kursa.Application.Features.Suggestions.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class SuggestionsController(ISender sender) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetSuggestionsAsync(CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetStudySuggestionsQuery(), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
+}

--- a/src/Kursa.Application/Common/Interfaces/IStudySuggestionService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IStudySuggestionService.cs
@@ -1,0 +1,9 @@
+using Kursa.Application.Features.Suggestions.Models;
+
+namespace Kursa.Application.Common.Interfaces;
+
+public interface IStudySuggestionService
+{
+    Task<IReadOnlyList<StudySuggestionDto>> GenerateSuggestionsAsync(
+        Guid userId, CancellationToken cancellationToken = default);
+}

--- a/src/Kursa.Application/Features/Suggestions/Models/StudySuggestionDto.cs
+++ b/src/Kursa.Application/Features/Suggestions/Models/StudySuggestionDto.cs
@@ -1,0 +1,10 @@
+namespace Kursa.Application.Features.Suggestions.Models;
+
+public sealed record StudySuggestionDto
+{
+    public string Type { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string? ActionUrl { get; init; }
+    public string Priority { get; init; } = "medium";
+}

--- a/src/Kursa.Application/Features/Suggestions/Queries/GetStudySuggestions.cs
+++ b/src/Kursa.Application/Features/Suggestions/Queries/GetStudySuggestions.cs
@@ -1,0 +1,34 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Suggestions.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Kursa.Application.Features.Suggestions.Queries;
+
+public sealed record GetStudySuggestionsQuery : IRequest<Result<IReadOnlyList<StudySuggestionDto>>>;
+
+public sealed class GetStudySuggestionsHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IStudySuggestionService suggestionService) : IRequestHandler<GetStudySuggestionsQuery, Result<IReadOnlyList<StudySuggestionDto>>>
+{
+    public async Task<Result<IReadOnlyList<StudySuggestionDto>>> Handle(
+        GetStudySuggestionsQuery request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<IReadOnlyList<StudySuggestionDto>>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<IReadOnlyList<StudySuggestionDto>>.Failure("User not found.");
+
+        IReadOnlyList<StudySuggestionDto> suggestions = await suggestionService
+            .GenerateSuggestionsAsync(user.Id, cancellationToken);
+
+        return Result<IReadOnlyList<StudySuggestionDto>>.Success(suggestions);
+    }
+}

--- a/src/Kursa.Frontend/src/app/core/services/suggestion.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/suggestion.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface StudySuggestion {
+  type: string;
+  title: string;
+  description: string;
+  actionUrl: string | null;
+  priority: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SuggestionService {
+  private readonly http = inject(HttpClient);
+
+  getSuggestions(): Observable<StudySuggestion[]> {
+    return this.http.get<StudySuggestion[]>('/api/suggestions');
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/src/Kursa.Frontend/src/app/features/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import {
   AnalyticsService,
   StudyActivity,
 } from '../../core/services/analytics.service';
+import { SuggestionService, StudySuggestion } from '../../core/services/suggestion.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -166,6 +167,53 @@ import {
             }
           </div>
 
+          <!-- AI Suggestions -->
+          <div class="rounded-lg border border-border bg-card p-5">
+            <div class="flex items-center gap-2">
+              <svg class="h-4 w-4 text-primary" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456Z" /></svg>
+              <h2 class="text-sm font-semibold text-foreground">AI Study Suggestions</h2>
+            </div>
+            @if (suggestionsLoading()) {
+              <div class="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+                <div class="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
+                Analyzing your study patterns...
+              </div>
+            } @else if (suggestions().length > 0) {
+              <div class="mt-3 space-y-2">
+                @for (s of suggestions(); track s.title) {
+                  @if (s.actionUrl) {
+                    <a
+                      [routerLink]="s.actionUrl"
+                      class="flex items-start gap-3 rounded-md p-2 transition-colors hover:bg-accent"
+                    >
+                      <div
+                        class="mt-0.5 h-2 w-2 shrink-0 rounded-full"
+                        [class]="s.priority === 'high' ? 'bg-orange-500' : s.priority === 'low' ? 'bg-muted-foreground' : 'bg-primary'"
+                      ></div>
+                      <div>
+                        <p class="text-sm font-medium text-foreground">{{ s.title }}</p>
+                        <p class="text-xs text-muted-foreground">{{ s.description }}</p>
+                      </div>
+                    </a>
+                  } @else {
+                    <div class="flex items-start gap-3 rounded-md p-2">
+                      <div
+                        class="mt-0.5 h-2 w-2 shrink-0 rounded-full"
+                        [class]="s.priority === 'high' ? 'bg-orange-500' : s.priority === 'low' ? 'bg-muted-foreground' : 'bg-primary'"
+                      ></div>
+                      <div>
+                        <p class="text-sm font-medium text-foreground">{{ s.title }}</p>
+                        <p class="text-xs text-muted-foreground">{{ s.description }}</p>
+                      </div>
+                    </div>
+                  }
+                }
+              </div>
+            } @else {
+              <p class="mt-3 text-xs text-muted-foreground">No suggestions available right now.</p>
+            }
+          </div>
+
           <!-- Streaks & Quick Actions -->
           <div class="space-y-4">
             <div class="rounded-lg border border-border bg-card p-5">
@@ -226,9 +274,12 @@ import {
 })
 export class DashboardComponent implements OnInit {
   private readonly analyticsService = inject(AnalyticsService);
+  private readonly suggestionService = inject(SuggestionService);
 
   readonly loading = signal(true);
   readonly data = signal<Analytics | null>(null);
+  readonly suggestions = signal<StudySuggestion[]>([]);
+  readonly suggestionsLoading = signal(true);
 
   ngOnInit(): void {
     this.analyticsService.getAnalytics().subscribe({
@@ -237,6 +288,14 @@ export class DashboardComponent implements OnInit {
         this.loading.set(false);
       },
       error: () => this.loading.set(false),
+    });
+
+    this.suggestionService.getSuggestions().subscribe({
+      next: (suggestions) => {
+        this.suggestions.set(suggestions);
+        this.suggestionsLoading.set(false);
+      },
+      error: () => this.suggestionsLoading.set(false),
     });
   }
 

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -76,6 +76,9 @@ public static class DependencyInjection
         // Recording indexing (transcript → embeddings + summary)
         services.AddScoped<IRecordingIndexingService, RecordingIndexingService>();
 
+        // AI study suggestions (agentic behavior)
+        services.AddScoped<IStudySuggestionService, StudySuggestionService>();
+
         // Microsoft Graph (OneNote + SharePoint)
         services.AddHttpClient("MicrosoftGraph");
         services.AddScoped<IMicrosoftGraphService, MicrosoftGraphService>();

--- a/src/Kursa.Infrastructure/Services/StudySuggestionService.cs
+++ b/src/Kursa.Infrastructure/Services/StudySuggestionService.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Features.Suggestions.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Infrastructure.Services;
+
+public sealed class StudySuggestionService(
+    IAppDbContext dbContext,
+    ILlmProvider llmProvider,
+    ILogger<StudySuggestionService> logger) : IStudySuggestionService
+{
+    public async Task<IReadOnlyList<StudySuggestionDto>> GenerateSuggestionsAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        string context = await BuildStudyContextAsync(userId, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(context))
+        {
+            return [
+                new StudySuggestionDto
+                {
+                    Type = "getting-started",
+                    Title = "Get started with Kursa",
+                    Description = "Link your Moodle account, pin some content, and start studying!",
+                    ActionUrl = "/courses",
+                    Priority = "high",
+                }
+            ];
+        }
+
+        try
+        {
+            return await GenerateWithLlmAsync(context, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to generate AI suggestions, falling back to rule-based");
+            return GenerateRuleBasedSuggestions(context);
+        }
+    }
+
+    private async Task<string> BuildStudyContextAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var parts = new List<string>();
+
+        // Flashcards due for review
+        int flashcardsDue = await dbContext.Flashcards
+            .CountAsync(f => f.Deck.UserId == userId && f.NextReviewAt <= DateTime.UtcNow, cancellationToken);
+
+        if (flashcardsDue > 0)
+            parts.Add($"Flashcards due for review: {flashcardsDue}");
+
+        // Recent quiz performance
+        var recentQuizzes = await dbContext.QuizAttempts
+            .Where(a => a.Quiz.UserId == userId)
+            .OrderByDescending(a => a.CompletedAt)
+            .Take(5)
+            .Select(a => new { a.Quiz.Title, a.Score, a.TotalQuestions })
+            .ToListAsync(cancellationToken);
+
+        if (recentQuizzes.Count > 0)
+        {
+            double avgScore = recentQuizzes.Average(q => q.TotalQuestions > 0 ? (double)q.Score / q.TotalQuestions * 100 : 0);
+            parts.Add($"Recent quiz average: {avgScore:F0}% across {recentQuizzes.Count} attempts");
+            foreach (var q in recentQuizzes)
+                parts.Add($"  - {q.Title}: {q.Score}/{q.TotalQuestions}");
+        }
+
+        // Study sessions this week
+        DateTime weekAgo = DateTime.UtcNow.AddDays(-7);
+        int sessionsThisWeek = await dbContext.StudySessions
+            .CountAsync(s => s.UserId == userId && s.CreatedAt >= weekAgo, cancellationToken);
+
+        int totalMinutes = await dbContext.StudySessions
+            .Where(s => s.UserId == userId && s.CreatedAt >= weekAgo)
+            .SumAsync(s => s.TotalDurationSeconds / 60, cancellationToken);
+
+        parts.Add($"Study sessions this week: {sessionsThisWeek} ({totalMinutes} minutes)");
+
+        // Flashcard decks
+        int deckCount = await dbContext.FlashcardDecks
+            .CountAsync(d => d.UserId == userId, cancellationToken);
+        int totalCards = await dbContext.Flashcards
+            .CountAsync(f => f.Deck.UserId == userId, cancellationToken);
+        parts.Add($"Flashcard decks: {deckCount} ({totalCards} cards total)");
+
+        // Recordings
+        int recordingCount = await dbContext.Recordings
+            .CountAsync(r => r.UserId == userId, cancellationToken);
+        if (recordingCount > 0)
+            parts.Add($"Recordings: {recordingCount}");
+
+        // Pinned content
+        int pinnedCount = await dbContext.PinnedContents
+            .CountAsync(p => p.UserId == userId, cancellationToken);
+        parts.Add($"Pinned content items: {pinnedCount}");
+
+        return string.Join("\n", parts);
+    }
+
+    private async Task<IReadOnlyList<StudySuggestionDto>> GenerateWithLlmAsync(
+        string context, CancellationToken cancellationToken)
+    {
+        string systemPrompt = """
+            You are a study advisor AI. Based on the student's study data below, generate 3-5 actionable study suggestions.
+            Each suggestion must be a JSON object with: type, title, description, actionUrl, priority.
+
+            Types: "review" (flashcard review), "quiz" (take a quiz), "study" (study session), "record" (record a lecture), "explore" (explore content)
+            Priorities: "high", "medium", "low"
+            Action URLs: /flashcards, /quizzes, /study, /recordings, /courses, /chat, /pinned
+
+            Return ONLY a JSON array of suggestion objects, no other text.
+            Be specific and actionable. Reference actual numbers from the data.
+            """;
+
+        var request = new LlmChatRequest
+        {
+            SystemPrompt = systemPrompt,
+            Messages = [LlmMessage.User(context)],
+            Temperature = 0.7f,
+            MaxTokens = 800,
+        };
+
+        LlmChatResponse response = await llmProvider.ChatAsync(request, cancellationToken);
+
+        // Parse JSON response
+        string content = response.Content.Trim();
+        // Strip markdown code block if present
+        if (content.StartsWith("```"))
+        {
+            int firstNewline = content.IndexOf('\n');
+            int lastBackticks = content.LastIndexOf("```");
+            if (firstNewline > 0 && lastBackticks > firstNewline)
+                content = content[(firstNewline + 1)..lastBackticks].Trim();
+        }
+
+        var suggestions = JsonSerializer.Deserialize<List<StudySuggestionDto>>(content, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        });
+
+        return suggestions ?? [];
+    }
+
+    private static IReadOnlyList<StudySuggestionDto> GenerateRuleBasedSuggestions(string context)
+    {
+        var suggestions = new List<StudySuggestionDto>();
+
+        if (context.Contains("Flashcards due for review:"))
+        {
+            suggestions.Add(new StudySuggestionDto
+            {
+                Type = "review",
+                Title = "Review your flashcards",
+                Description = "You have flashcards due for review. Keeping up with spaced repetition improves long-term retention.",
+                ActionUrl = "/flashcards",
+                Priority = "high",
+            });
+        }
+
+        if (context.Contains("Recent quiz average:"))
+        {
+            suggestions.Add(new StudySuggestionDto
+            {
+                Type = "quiz",
+                Title = "Take a practice quiz",
+                Description = "Regular quizzing strengthens recall. Try generating a quiz from your pinned materials.",
+                ActionUrl = "/quizzes",
+                Priority = "medium",
+            });
+        }
+
+        if (context.Contains("0 minutes"))
+        {
+            suggestions.Add(new StudySuggestionDto
+            {
+                Type = "study",
+                Title = "Start a study session",
+                Description = "You haven't studied this week. Even a short 25-minute Pomodoro session can make a difference.",
+                ActionUrl = "/study",
+                Priority = "high",
+            });
+        }
+
+        if (suggestions.Count == 0)
+        {
+            suggestions.Add(new StudySuggestionDto
+            {
+                Type = "explore",
+                Title = "Explore your courses",
+                Description = "Browse your course materials and pin content you want to study with AI assistance.",
+                ActionUrl = "/courses",
+                Priority = "medium",
+            });
+        }
+
+        return suggestions;
+    }
+}


### PR DESCRIPTION
## Summary
- Backend: `StudySuggestionService` analyzes user's study data (flashcards due, quiz performance, study sessions, recordings, pinned content) and generates personalized suggestions via LLM, with rule-based fallback if LLM fails
- `SuggestionsController` at `GET /api/suggestions` returns prioritized study suggestions
- Frontend: AI Study Suggestions widget on dashboard showing priority-colored suggestions with action links to relevant features

## Test plan
- [ ] Backend and frontend build with 0 warnings
- [ ] Suggestions endpoint returns data based on user's study activity
- [ ] Dashboard shows AI suggestions widget with loading state
- [ ] Rule-based fallback works when LLM is unavailable
- [ ] Suggestion action links navigate to correct feature pages

Closes #27