### PR TITLE
fix(moodle): route all Moodle calls through MoodlewareAPI bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,10 @@ MINIO_SECRET_KEY=minioadmin
 # ========================
 # Moodle Integration
 # ========================
-MOODLE_API_BASE_URL=https://your-school.schulnetz.ch
-MOODLE_TOKEN=your_moodle_token_here
+# The actual Moodle instance URL (used by MoodlewareAPI bridge)
+MOODLE_URL=https://your-school.moodle.ch
+# Secret key for MoodlewareAPI session signing
+MOODLEWARE_SECRET_KEY=change_me_in_production
 
 # ========================
 # Microsoft Graph (OneNote, SharePoint, Calendar)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,22 @@
 services:
   # ========================
+  # MoodlewareAPI Bridge
+  # ========================
+  moodlewareapi:
+    image: ghcr.io/moodleng/moodlewareapi:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - MOODLE_URL=${MOODLE_URL}
+      - ALLOW_ORIGINS=*
+      - LOG_LEVEL=info
+      - REDIS_URL=redis://redis:6379/1
+      - SECRET_KEY=${MOODLEWARE_SECRET_KEY:-change_me_in_production}
+    depends_on:
+      - redis
+    restart: unless-stopped
+
+  # ========================
   # Backend API
   # ========================
   api:
@@ -17,7 +34,7 @@ services:
       - MinIO__Endpoint=minio:9000
       - MinIO__AccessKey=${MINIO_ACCESS_KEY}
       - MinIO__SecretKey=${MINIO_SECRET_KEY}
-      - Moodle__ApiBaseUrl=${MOODLE_API_BASE_URL}
+      - Moodle__BridgeUrl=http://moodlewareapi:8000
       - Llm__Provider=${LLM_PROVIDER:-openai}
       - Llm__ApiKey=${LLM_API_KEY}
       - Llm__Model=${LLM_MODEL:-gpt-4o-mini}
@@ -30,6 +47,8 @@ services:
       qdrant:
         condition: service_started
       minio:
+        condition: service_started
+      moodlewareapi:
         condition: service_started
     restart: unless-stopped
 

--- a/src/Kursa.API/appsettings.json
+++ b/src/Kursa.API/appsettings.json
@@ -35,7 +35,7 @@
     "BucketName": "kursa"
   },
   "Moodle": {
-    "ApiBaseUrl": ""
+    "BridgeUrl": "http://localhost:8000"
   },
   "Llm": {
     "Provider": "openai",

--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -5,28 +5,28 @@ namespace Kursa.Application.Common.Interfaces;
 public interface IMoodleService
 {
     Task<IReadOnlyList<MoodleCourseDto>> GetEnrolledCoursesAsync(
-        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default);
+        string moodleToken, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<MoodleCourseSectionDto>> GetCourseContentAsync(
-        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default);
+        string moodleToken, int courseId, CancellationToken cancellationToken = default);
 
     Task<MoodleSiteInfoDto> GetSiteInfoAsync(
-        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default);
+        string moodleToken, CancellationToken cancellationToken = default);
 
     Task<MoodleAssignmentsResponseDto> GetAssignmentsAsync(
-        string moodleUrl, string moodleToken, IReadOnlyList<int>? courseIds = null,
+        string moodleToken, IReadOnlyList<int>? courseIds = null,
         CancellationToken cancellationToken = default);
 
     Task<MoodleGradeReportDto> GetGradesAsync(
-        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default);
+        string moodleToken, int courseId, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<MoodleForumDto>> GetForumsAsync(
-        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default);
+        string moodleToken, int courseId, CancellationToken cancellationToken = default);
 
     Task<MoodleForumDiscussionsResponseDto> GetForumDiscussionsAsync(
-        string moodleUrl, string moodleToken, int forumId, CancellationToken cancellationToken = default);
+        string moodleToken, int forumId, CancellationToken cancellationToken = default);
 
     Task<MoodleCalendarEventsResponseDto> GetCalendarEventsAsync(
-        string moodleUrl, string moodleToken, long timeStart, long timeEnd,
+        string moodleToken, long timeStart, long timeEnd,
         CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Application/Features/Moodle/Commands/LinkMoodleToken.cs
+++ b/src/Kursa.Application/Features/Moodle/Commands/LinkMoodleToken.cs
@@ -6,20 +6,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Kursa.Application.Features.Moodle.Commands;
 
-public sealed record LinkMoodleTokenCommand(
-    string MoodleUrl,
-    string Token) : IRequest<Result>;
+public sealed record LinkMoodleTokenCommand(string Token) : IRequest<Result>;
 
 public sealed class LinkMoodleTokenValidator : AbstractValidator<LinkMoodleTokenCommand>
 {
     public LinkMoodleTokenValidator()
     {
-        RuleFor(x => x.MoodleUrl)
-            .NotEmpty()
-            .MaximumLength(512)
-            .Must(url => Uri.TryCreate(url, UriKind.Absolute, out _))
-            .WithMessage("Moodle URL must be a valid absolute URL.");
-
         RuleFor(x => x.Token)
             .NotEmpty()
             .MaximumLength(512);
@@ -45,7 +37,6 @@ public sealed class LinkMoodleTokenHandler(
             return Result.Failure("User not found.");
         }
 
-        user.MoodleUrl = request.MoodleUrl.TrimEnd('/');
         user.MoodleToken = request.Token;
 
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/Kursa.Application/Features/Moodle/Queries/GetAssignments.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetAssignments.cs
@@ -26,7 +26,7 @@ public sealed class GetAssignmentsHandler(
         if (user is null)
             return Result<IReadOnlyList<AssignmentViewDto>>.Failure("User not found.");
 
-        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+        if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<AssignmentViewDto>>.Failure("Moodle account is not linked.");
 
         IReadOnlyList<int>? courseIds = request.CourseId.HasValue
@@ -34,7 +34,7 @@ public sealed class GetAssignmentsHandler(
             : null;
 
         MoodleAssignmentsResponseDto response = await moodleService.GetAssignmentsAsync(
-            user.MoodleUrl, user.MoodleToken, courseIds, cancellationToken);
+            user.MoodleToken, courseIds, cancellationToken);
 
         DateTime utcNow = DateTime.UtcNow;
 

--- a/src/Kursa.Application/Features/Moodle/Queries/GetCalendarEvents.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetCalendarEvents.cs
@@ -26,7 +26,7 @@ public sealed class GetCalendarEventsHandler(
         if (user is null)
             return Result<IReadOnlyList<CalendarEventViewDto>>.Failure("User not found.");
 
-        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+        if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<CalendarEventViewDto>>.Failure("Moodle account is not linked.");
 
         DateTime weekEnd = request.WeekStart.AddDays(7);
@@ -34,7 +34,7 @@ public sealed class GetCalendarEventsHandler(
         long timeEnd = new DateTimeOffset(weekEnd, TimeSpan.Zero).ToUnixTimeSeconds();
 
         MoodleCalendarEventsResponseDto response = await moodleService.GetCalendarEventsAsync(
-            user.MoodleUrl, user.MoodleToken, timeStart, timeEnd, cancellationToken);
+            user.MoodleToken, timeStart, timeEnd, cancellationToken);
 
         var events = response.Events
             .Select(e =>

--- a/src/Kursa.Application/Features/Moodle/Queries/GetCourseContent.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetCourseContent.cs
@@ -35,11 +35,11 @@ public sealed class GetCourseContentHandler(
         if (user is null)
             return Result<IReadOnlyList<MoodleCourseSectionDto>>.Failure("User not found.");
 
-        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+        if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<MoodleCourseSectionDto>>.Failure("Moodle account is not linked.");
 
         var sections = await moodleService.GetCourseContentAsync(
-            user.MoodleUrl, user.MoodleToken, request.MoodleCourseId, cancellationToken);
+            user.MoodleToken, request.MoodleCourseId, cancellationToken);
 
         return Result<IReadOnlyList<MoodleCourseSectionDto>>.Success(sections);
     }

--- a/src/Kursa.Application/Features/Moodle/Queries/GetEnrolledCourses.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetEnrolledCourses.cs
@@ -26,11 +26,11 @@ public sealed class GetEnrolledCoursesHandler(
         if (user is null)
             return Result<IReadOnlyList<MoodleCourseDto>>.Failure("User not found.");
 
-        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+        if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<MoodleCourseDto>>.Failure("Moodle account is not linked.");
 
         var courses = await moodleService.GetEnrolledCoursesAsync(
-            user.MoodleUrl, user.MoodleToken, cancellationToken);
+            user.MoodleToken, cancellationToken);
 
         return Result<IReadOnlyList<MoodleCourseDto>>.Success(courses);
     }

--- a/src/Kursa.Application/Features/Moodle/Queries/GetForumDiscussions.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetForumDiscussions.cs
@@ -26,11 +26,11 @@ public sealed class GetForumDiscussionsHandler(
         if (user is null)
             return Result<IReadOnlyList<DiscussionViewDto>>.Failure("User not found.");
 
-        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+        if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<DiscussionViewDto>>.Failure("Moodle account is not linked.");
 
         MoodleForumDiscussionsResponseDto response = await moodleService.GetForumDiscussionsAsync(
-            user.MoodleUrl, user.MoodleToken, request.ForumId, cancellationToken);
+            user.MoodleToken, request.ForumId, cancellationToken);
 
         var result = response.Discussions
             .Select(d => new DiscussionViewDto

--- a/src/Kursa.Application/Features/Moodle/Queries/GetForums.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetForums.cs
@@ -26,11 +26,11 @@ public sealed class GetForumsHandler(
         if (user is null)
             return Result<IReadOnlyList<ForumViewDto>>.Failure("User not found.");
 
-        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+        if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<ForumViewDto>>.Failure("Moodle account is not linked.");
 
         IReadOnlyList<MoodleForumDto> forums = await moodleService.GetForumsAsync(
-            user.MoodleUrl, user.MoodleToken, request.CourseId, cancellationToken);
+            user.MoodleToken, request.CourseId, cancellationToken);
 
         var result = forums.Select(f => new ForumViewDto
         {

--- a/src/Kursa.Application/Features/Moodle/Queries/GetGrades.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetGrades.cs
@@ -26,26 +26,26 @@ public sealed class GetGradesHandler(
         if (user is null)
             return Result<IReadOnlyList<CourseGradeSummaryDto>>.Failure("User not found.");
 
-        if (string.IsNullOrEmpty(user.MoodleToken) || string.IsNullOrEmpty(user.MoodleUrl))
+        if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<CourseGradeSummaryDto>>.Failure("Moodle account is not linked.");
 
         // If a specific course is requested, fetch just that one
         if (request.CourseId.HasValue)
         {
             CourseGradeSummaryDto summary = await GetCourseGradeSummaryAsync(
-                user.MoodleUrl, user.MoodleToken, request.CourseId.Value, cancellationToken);
+                user.MoodleToken, request.CourseId.Value, cancellationToken);
             return Result<IReadOnlyList<CourseGradeSummaryDto>>.Success([summary]);
         }
 
         // Otherwise fetch grades for all enrolled courses
         IReadOnlyList<MoodleCourseDto> courses = await moodleService.GetEnrolledCoursesAsync(
-            user.MoodleUrl, user.MoodleToken, cancellationToken);
+            user.MoodleToken, cancellationToken);
 
         var summaries = new List<CourseGradeSummaryDto>();
         foreach (MoodleCourseDto course in courses)
         {
             CourseGradeSummaryDto summary = await GetCourseGradeSummaryAsync(
-                user.MoodleUrl, user.MoodleToken, course.Id, cancellationToken);
+                user.MoodleToken, course.Id, cancellationToken);
 
             // Only include courses that have grade items
             if (summary.TotalItemCount > 0)
@@ -56,10 +56,10 @@ public sealed class GetGradesHandler(
     }
 
     private async Task<CourseGradeSummaryDto> GetCourseGradeSummaryAsync(
-        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken)
+        string moodleToken, int courseId, CancellationToken cancellationToken)
     {
         MoodleGradeReportDto report = await moodleService.GetGradesAsync(
-            moodleUrl, moodleToken, courseId, cancellationToken);
+            moodleToken, courseId, cancellationToken);
 
         MoodleUserGradeDto? userGrade = report.UserGrades.FirstOrDefault();
 

--- a/src/Kursa.Infrastructure/Options/MoodleOptions.cs
+++ b/src/Kursa.Infrastructure/Options/MoodleOptions.cs
@@ -4,5 +4,6 @@ public sealed class MoodleOptions
 {
     public const string SectionName = "Moodle";
 
-    public string ApiBaseUrl { get; init; } = string.Empty;
+    /// <summary>Base URL of the MoodlewareAPI bridge (e.g. http://localhost:8000).</summary>
+    public string BridgeUrl { get; init; } = string.Empty;
 }

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -3,13 +3,16 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using Kursa.Application.Common.Interfaces;
 using Kursa.Application.Features.Moodle.Models;
+using Kursa.Infrastructure.Options;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Kursa.Infrastructure.Services;
 
 public sealed class MoodleService(
     IHttpClientFactory httpClientFactory,
+    IOptions<MoodleOptions> moodleOptions,
     IDistributedCache cache,
     ILogger<MoodleService> logger) : IMoodleService
 {
@@ -21,8 +24,10 @@ public sealed class MoodleService(
     private static readonly TimeSpan CourseCacheDuration = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan ContentCacheDuration = TimeSpan.FromMinutes(2);
 
+    private string BridgeUrl => moodleOptions.Value.BridgeUrl.TrimEnd('/');
+
     public async Task<IReadOnlyList<MoodleCourseDto>> GetEnrolledCoursesAsync(
-        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default)
+        string moodleToken, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"moodle:courses:{HashToken(moodleToken)}";
 
@@ -30,11 +35,9 @@ public sealed class MoodleService(
         if (cached is not null)
             return cached;
 
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, "/core_enrol_get_users_courses", cancellationToken);
+        var response = await SendRequestAsync(moodleToken, "/core_enrol_get_users_courses", cancellationToken);
 
-        var courses = JsonSerializer.Deserialize<List<MoodleCourseDto>>(response, JsonOptions)
-            ?? [];
+        var courses = JsonSerializer.Deserialize<List<MoodleCourseDto>>(response, JsonOptions) ?? [];
 
         await SetCacheAsync(cacheKey, courses, CourseCacheDuration, cancellationToken);
 
@@ -42,7 +45,7 @@ public sealed class MoodleService(
     }
 
     public async Task<IReadOnlyList<MoodleCourseSectionDto>> GetCourseContentAsync(
-        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default)
+        string moodleToken, int courseId, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"moodle:content:{HashToken(moodleToken)}:{courseId}";
 
@@ -50,11 +53,10 @@ public sealed class MoodleService(
         if (cached is not null)
             return cached;
 
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, $"/core_course_get_contents?courseid={courseId}", cancellationToken);
+        var response = await SendRequestAsync(
+            moodleToken, $"/core_course_get_contents?courseid={courseId}", cancellationToken);
 
-        var sections = JsonSerializer.Deserialize<List<MoodleCourseSectionDto>>(response, JsonOptions)
-            ?? [];
+        var sections = JsonSerializer.Deserialize<List<MoodleCourseSectionDto>>(response, JsonOptions) ?? [];
 
         await SetCacheAsync(cacheKey, sections, ContentCacheDuration, cancellationToken);
 
@@ -62,17 +64,16 @@ public sealed class MoodleService(
     }
 
     public async Task<MoodleSiteInfoDto> GetSiteInfoAsync(
-        string moodleUrl, string moodleToken, CancellationToken cancellationToken = default)
+        string moodleToken, CancellationToken cancellationToken = default)
     {
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, "/core_webservice_get_site_info", cancellationToken);
+        var response = await SendRequestAsync(moodleToken, "/core_webservice_get_site_info", cancellationToken);
 
         return JsonSerializer.Deserialize<MoodleSiteInfoDto>(response, JsonOptions)
             ?? throw new InvalidOperationException("Failed to deserialize Moodle site info.");
     }
 
     public async Task<MoodleAssignmentsResponseDto> GetAssignmentsAsync(
-        string moodleUrl, string moodleToken, IReadOnlyList<int>? courseIds = null,
+        string moodleToken, IReadOnlyList<int>? courseIds = null,
         CancellationToken cancellationToken = default)
     {
         string courseParam = courseIds is { Count: > 0 }
@@ -85,8 +86,8 @@ public sealed class MoodleService(
         if (cached is not null)
             return cached;
 
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, $"/mod_assign_get_assignments{courseParam}", cancellationToken);
+        var response = await SendRequestAsync(
+            moodleToken, $"/mod_assign_get_assignments{courseParam}", cancellationToken);
 
         var result = JsonSerializer.Deserialize<MoodleAssignmentsResponseDto>(response, JsonOptions)
             ?? new MoodleAssignmentsResponseDto();
@@ -97,7 +98,7 @@ public sealed class MoodleService(
     }
 
     public async Task<MoodleGradeReportDto> GetGradesAsync(
-        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default)
+        string moodleToken, int courseId, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"moodle:grades:{HashToken(moodleToken)}:{courseId}";
 
@@ -105,8 +106,8 @@ public sealed class MoodleService(
         if (cached is not null)
             return cached;
 
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, $"/gradereport_user_get_grade_items?courseid={courseId}", cancellationToken);
+        var response = await SendRequestAsync(
+            moodleToken, $"/gradereport_user_get_grade_items?courseid={courseId}", cancellationToken);
 
         var result = JsonSerializer.Deserialize<MoodleGradeReportDto>(response, JsonOptions)
             ?? new MoodleGradeReportDto();
@@ -117,7 +118,7 @@ public sealed class MoodleService(
     }
 
     public async Task<IReadOnlyList<MoodleForumDto>> GetForumsAsync(
-        string moodleUrl, string moodleToken, int courseId, CancellationToken cancellationToken = default)
+        string moodleToken, int courseId, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"moodle:forums:{HashToken(moodleToken)}:{courseId}";
 
@@ -125,8 +126,8 @@ public sealed class MoodleService(
         if (cached is not null)
             return cached;
 
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, $"/mod_forum_get_forums_by_courses?courseids[0]={courseId}", cancellationToken);
+        var response = await SendRequestAsync(
+            moodleToken, $"/mod_forum_get_forums_by_courses?courseids[0]={courseId}", cancellationToken);
 
         var forums = JsonSerializer.Deserialize<List<MoodleForumDto>>(response, JsonOptions) ?? [];
 
@@ -136,7 +137,7 @@ public sealed class MoodleService(
     }
 
     public async Task<MoodleForumDiscussionsResponseDto> GetForumDiscussionsAsync(
-        string moodleUrl, string moodleToken, int forumId, CancellationToken cancellationToken = default)
+        string moodleToken, int forumId, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"moodle:discussions:{HashToken(moodleToken)}:{forumId}";
 
@@ -144,8 +145,8 @@ public sealed class MoodleService(
         if (cached is not null)
             return cached;
 
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, $"/mod_forum_get_forum_discussions?forumid={forumId}", cancellationToken);
+        var response = await SendRequestAsync(
+            moodleToken, $"/mod_forum_get_forum_discussions?forumid={forumId}", cancellationToken);
 
         var result = JsonSerializer.Deserialize<MoodleForumDiscussionsResponseDto>(response, JsonOptions)
             ?? new MoodleForumDiscussionsResponseDto();
@@ -156,7 +157,7 @@ public sealed class MoodleService(
     }
 
     public async Task<MoodleCalendarEventsResponseDto> GetCalendarEventsAsync(
-        string moodleUrl, string moodleToken, long timeStart, long timeEnd,
+        string moodleToken, long timeStart, long timeEnd,
         CancellationToken cancellationToken = default)
     {
         string cacheKey = $"moodle:calendar:{HashToken(moodleToken)}:{timeStart}:{timeEnd}";
@@ -167,8 +168,7 @@ public sealed class MoodleService(
 
         string endpoint = $"/core_calendar_get_calendar_events?events[timestart]={timeStart}&events[timeend]={timeEnd}";
 
-        var response = await SendMoodleRequestAsync(
-            moodleUrl, moodleToken, endpoint, cancellationToken);
+        var response = await SendRequestAsync(moodleToken, endpoint, cancellationToken);
 
         var result = JsonSerializer.Deserialize<MoodleCalendarEventsResponseDto>(response, JsonOptions)
             ?? new MoodleCalendarEventsResponseDto();
@@ -178,11 +178,11 @@ public sealed class MoodleService(
         return result;
     }
 
-    private async Task<string> SendMoodleRequestAsync(
-        string moodleUrl, string moodleToken, string endpoint, CancellationToken cancellationToken)
+    private async Task<string> SendRequestAsync(
+        string moodleToken, string endpoint, CancellationToken cancellationToken)
     {
         using var client = httpClientFactory.CreateClient("Moodle");
-        client.BaseAddress = new Uri(moodleUrl.TrimEnd('/'));
+        client.BaseAddress = new Uri(BridgeUrl);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", moodleToken);
         client.Timeout = TimeSpan.FromSeconds(30);
 
@@ -192,17 +192,17 @@ public sealed class MoodleService(
 
         if (response.StatusCode == HttpStatusCode.Unauthorized)
         {
-            logger.LogWarning("Moodle API returned 401 Unauthorized for endpoint {Endpoint}", endpoint);
+            logger.LogWarning("MoodlewareAPI returned 401 for endpoint {Endpoint}", endpoint);
             throw new UnauthorizedAccessException("Moodle token is invalid or expired. Please re-link your Moodle account.");
         }
 
         if (!response.IsSuccessStatusCode)
         {
             string body = await response.Content.ReadAsStringAsync(cancellationToken);
-            logger.LogError("Moodle API error {StatusCode} for {Endpoint}: {Body}",
+            logger.LogError("MoodlewareAPI error {StatusCode} for {Endpoint}: {Body}",
                 (int)response.StatusCode, endpoint, body);
             throw new HttpRequestException(
-                $"Moodle API returned {(int)response.StatusCode}: {response.ReasonPhrase}");
+                $"MoodlewareAPI returned {(int)response.StatusCode}: {response.ReasonPhrase}");
         }
 
         return await response.Content.ReadAsStringAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- Add `moodlewareapi` service to `docker-compose.yml` using `ghcr.io/moodleng/moodlewareapi:latest`
- Replace `MoodleOptions.ApiBaseUrl` with `BridgeUrl` — Kursa.API now calls MoodlewareAPI, not Moodle directly
- Remove `moodleUrl` parameter from `IMoodleService` and all implementations — bridge URL is internal config
- Remove `MoodleUrl` from `LinkMoodleTokenCommand` — only the Moodle token is needed per user
- Update all query handlers to drop `user.MoodleUrl` from service calls

## Test plan
- [ ] `dotnet build` passes with 0 errors, 0 warnings
- [ ] `docker compose up -d` starts all services including `moodlewareapi` on port 8000
- [ ] Linking a Moodle token via Settings only requires the token (no URL input)
- [ ] Moodle API calls route through MoodlewareAPI at configured `BridgeUrl`
- [ ] No secrets or credentials in diff

Closes #71