### PR TITLE
fix(moodle): authenticate via MoodlewareAPI /auth instead of raw token

### DIFF
--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -4,6 +4,9 @@ namespace Kursa.Application.Common.Interfaces;
 
 public interface IMoodleService
 {
+    /// <summary>Authenticates with MoodlewareAPI using Moodle credentials and returns the wstoken, or null on failure.</summary>
+    Task<string?> GetTokenAsync(string username, string password, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<MoodleCourseDto>> GetEnrolledCoursesAsync(
         string moodleToken, CancellationToken cancellationToken = default);
 

--- a/src/Kursa.Application/Features/Moodle/Commands/LinkMoodleToken.cs
+++ b/src/Kursa.Application/Features/Moodle/Commands/LinkMoodleToken.cs
@@ -6,27 +6,33 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Kursa.Application.Features.Moodle.Commands;
 
-public sealed record LinkMoodleTokenCommand(string Token) : IRequest<Result>;
+public sealed record LinkMoodleTokenCommand(string Username, string Password) : IRequest<Result>;
 
 public sealed class LinkMoodleTokenValidator : AbstractValidator<LinkMoodleTokenCommand>
 {
     public LinkMoodleTokenValidator()
     {
-        RuleFor(x => x.Token)
-            .NotEmpty()
-            .MaximumLength(512);
+        RuleFor(x => x.Username).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.Password).NotEmpty().MaximumLength(512);
     }
 }
 
 public sealed class LinkMoodleTokenHandler(
     ICurrentUserService currentUserService,
-    IAppDbContext dbContext) : IRequestHandler<LinkMoodleTokenCommand, Result>
+    IAppDbContext dbContext,
+    IMoodleService moodleService) : IRequestHandler<LinkMoodleTokenCommand, Result>
 {
     public async Task<Result> Handle(LinkMoodleTokenCommand request, CancellationToken cancellationToken)
     {
         if (currentUserService.ExternalId is null)
         {
             return Result.Failure("User is not authenticated.");
+        }
+
+        var token = await moodleService.GetTokenAsync(request.Username, request.Password, cancellationToken);
+        if (token is null)
+        {
+            return Result.Failure("Invalid Moodle credentials.");
         }
 
         var user = await dbContext.Users
@@ -37,7 +43,7 @@ public sealed class LinkMoodleTokenHandler(
             return Result.Failure("User not found.");
         }
 
-        user.MoodleToken = request.Token;
+        user.MoodleToken = token;
 
         await dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/Kursa.Frontend/src/app/core/services/moodle.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/moodle.service.ts
@@ -61,8 +61,8 @@ export class MoodleService {
     return this.http.get<MoodleConnectionStatus>(`${this.baseUrl}/status`);
   }
 
-  linkToken(token: string): Observable<void> {
-    return this.http.post<void>(`${this.baseUrl}/link`, { token });
+  linkMoodle(username: string, password: string): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/link`, { username, password });
   }
 
   unlinkToken(): Observable<void> {

--- a/src/Kursa.Frontend/src/app/features/onboarding/onboarding.component.ts
+++ b/src/Kursa.Frontend/src/app/features/onboarding/onboarding.component.ts
@@ -40,27 +40,29 @@ import { MoodleService } from '../../core/services/moodle.service';
               <div class="space-y-4">
                 <h2 class="text-xl font-bold text-foreground">Connect Moodle</h2>
                 <p class="text-sm text-muted-foreground">
-                  Link your Moodle account to browse courses and content.
+                  Enter your Moodle credentials to link your account.
                 </p>
 
                 <div class="space-y-3">
                   <div>
-                    <label for="moodle-url" class="block text-sm font-medium text-foreground">Moodle URL</label>
+                    <label for="moodle-username" class="block text-sm font-medium text-foreground">Username</label>
                     <input
-                      id="moodle-url"
-                      type="url"
-                      [(ngModel)]="moodleUrl"
-                      placeholder="https://moodle.example.com"
+                      id="moodle-username"
+                      type="text"
+                      [(ngModel)]="moodleUsername"
+                      autocomplete="username"
+                      placeholder="Your Moodle username"
                       class="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     />
                   </div>
                   <div>
-                    <label for="moodle-token" class="block text-sm font-medium text-foreground">API Token</label>
+                    <label for="moodle-password" class="block text-sm font-medium text-foreground">Password</label>
                     <input
-                      id="moodle-token"
+                      id="moodle-password"
                       type="password"
-                      [(ngModel)]="moodleToken"
-                      placeholder="Your Moodle API token"
+                      [(ngModel)]="moodlePassword"
+                      autocomplete="current-password"
+                      placeholder="Your Moodle password"
                       class="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     />
                   </div>
@@ -136,7 +138,7 @@ import { MoodleService } from '../../core/services/moodle.service';
                   (click)="next()"
                   class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
                 >
-                  {{ currentStep() === 1 && moodleUrl && moodleToken ? 'Connect & Continue' : 'Continue' }}
+                  {{ currentStep() === 1 && moodleUsername && moodlePassword ? 'Connect & Continue' : 'Continue' }}
                 </button>
               } @else {
                 <button
@@ -163,16 +165,23 @@ export class OnboardingComponent {
   readonly moodleLinkError = signal<string | null>(null);
   readonly moodleLinkSuccess = signal(false);
 
-  moodleUrl = '';
-  moodleToken = '';
+  moodleUsername = '';
+  moodlePassword = '';
   selectedTheme = 'dark';
 
   next(): void {
-    if (this.currentStep() === 1 && this.moodleUrl && this.moodleToken) {
-      // Attempt to link Moodle before proceeding
+    if (this.currentStep() === 1 && this.moodleUsername && this.moodlePassword) {
       this.moodleLinkError.set(null);
-      // The actual linking would go through the MoodleController
-      // For now, just advance
+      this.moodleService.linkMoodle(this.moodleUsername, this.moodlePassword).subscribe({
+        next: () => {
+          this.moodleLinkSuccess.set(true);
+          this.currentStep.update((s) => s + 1);
+        },
+        error: () => {
+          this.moodleLinkError.set('Invalid credentials. Please check and try again.');
+        },
+      });
+      return;
     }
 
     if (this.currentStep() < this.steps.length - 1) {

--- a/src/Kursa.Frontend/src/app/features/settings/settings.component.ts
+++ b/src/Kursa.Frontend/src/app/features/settings/settings.component.ts
@@ -21,7 +21,7 @@ import { MoodleService } from '../../core/services/moodle.service';
         <div>
           <h2 id="moodle-heading" class="text-lg font-semibold text-foreground">Moodle Integration</h2>
           <p class="mt-1 text-sm text-muted-foreground">
-            Connect your Moodle account to access courses, assignments, and grades.
+            Connect your Moodle account using your login credentials.
           </p>
         </div>
 
@@ -42,28 +42,47 @@ import { MoodleService } from '../../core/services/moodle.service';
             {{ isSubmitting() ? 'Disconnecting…' : 'Disconnect Moodle' }}
           </button>
         } @else {
-          <form [formGroup]="tokenForm" (ngSubmit)="linkMoodle()" class="space-y-4" novalidate>
+          <form [formGroup]="loginForm" (ngSubmit)="linkMoodle()" class="space-y-4" novalidate>
             <div>
-              <label for="moodle-token" class="block text-sm font-medium text-foreground">
-                Moodle API Token
+              <label for="moodle-username" class="block text-sm font-medium text-foreground">
+                Moodle Username
               </label>
-              <p class="mt-0.5 text-xs text-muted-foreground">
-                Find your token in Moodle → User menu → Preferences → Security keys.
-              </p>
               <input
-                id="moodle-token"
-                type="password"
-                formControlName="token"
-                autocomplete="current-password"
-                placeholder="Enter your Moodle API token"
+                id="moodle-username"
+                type="text"
+                formControlName="username"
+                autocomplete="username"
+                placeholder="Enter your Moodle username"
                 class="mt-2 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                [class]="tokenForm.controls.token.invalid && tokenForm.controls.token.touched ? 'border-destructive' : ''"
-                [attr.aria-describedby]="tokenForm.controls.token.invalid && tokenForm.controls.token.touched ? 'token-error' : null"
-                [attr.aria-invalid]="tokenForm.controls.token.invalid && tokenForm.controls.token.touched ? true : null"
+                [class]="loginForm.controls.username.invalid && loginForm.controls.username.touched ? 'border-destructive' : ''"
+                [attr.aria-invalid]="loginForm.controls.username.invalid && loginForm.controls.username.touched ? true : null"
+                [attr.aria-describedby]="loginForm.controls.username.invalid && loginForm.controls.username.touched ? 'username-error' : null"
               />
-              @if (tokenForm.controls.token.invalid && tokenForm.controls.token.touched) {
-                <p id="token-error" class="mt-1 text-xs text-destructive" role="alert">
-                  Please enter your Moodle API token.
+              @if (loginForm.controls.username.invalid && loginForm.controls.username.touched) {
+                <p id="username-error" class="mt-1 text-xs text-destructive" role="alert">
+                  Please enter your Moodle username.
+                </p>
+              }
+            </div>
+
+            <div>
+              <label for="moodle-password" class="block text-sm font-medium text-foreground">
+                Moodle Password
+              </label>
+              <input
+                id="moodle-password"
+                type="password"
+                formControlName="password"
+                autocomplete="current-password"
+                placeholder="Enter your Moodle password"
+                class="mt-2 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                [class]="loginForm.controls.password.invalid && loginForm.controls.password.touched ? 'border-destructive' : ''"
+                [attr.aria-invalid]="loginForm.controls.password.invalid && loginForm.controls.password.touched ? true : null"
+                [attr.aria-describedby]="loginForm.controls.password.invalid && loginForm.controls.password.touched ? 'password-error' : null"
+              />
+              @if (loginForm.controls.password.invalid && loginForm.controls.password.touched) {
+                <p id="password-error" class="mt-1 text-xs text-destructive" role="alert">
+                  Please enter your Moodle password.
                 </p>
               }
             </div>
@@ -74,7 +93,7 @@ import { MoodleService } from '../../core/services/moodle.service';
 
             <button
               type="submit"
-              [disabled]="isSubmitting() || tokenForm.invalid"
+              [disabled]="isSubmitting() || loginForm.invalid"
               class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ isSubmitting() ? 'Connecting…' : 'Connect Moodle' }}
@@ -93,15 +112,12 @@ export class SettingsComponent implements OnInit {
   readonly isSubmitting = signal(false);
   readonly errorMessage = signal<string | null>(null);
 
-  readonly tokenForm = this.fb.group({
-    token: ['', [Validators.required, Validators.minLength(1)]],
+  readonly loginForm = this.fb.group({
+    username: ['', [Validators.required]],
+    password: ['', [Validators.required]],
   });
 
   ngOnInit(): void {
-    this.loadStatus();
-  }
-
-  private loadStatus(): void {
     this.moodleService.getConnectionStatus().subscribe({
       next: (status) => this.isConnected.set(status.isConnected),
       error: () => this.isConnected.set(false),
@@ -109,20 +125,20 @@ export class SettingsComponent implements OnInit {
   }
 
   linkMoodle(): void {
-    if (this.tokenForm.invalid) return;
+    if (this.loginForm.invalid) return;
 
-    const token = this.tokenForm.controls.token.value!;
+    const { username, password } = this.loginForm.value;
     this.isSubmitting.set(true);
     this.errorMessage.set(null);
 
-    this.moodleService.linkToken(token).subscribe({
+    this.moodleService.linkMoodle(username!, password!).subscribe({
       next: () => {
         this.isConnected.set(true);
         this.isSubmitting.set(false);
-        this.tokenForm.reset();
+        this.loginForm.reset();
       },
       error: () => {
-        this.errorMessage.set('Failed to connect. Check your token and try again.');
+        this.errorMessage.set('Invalid credentials or Moodle unavailable. Please try again.');
         this.isSubmitting.set(false);
       },
     });

--- a/src/Kursa.Infrastructure/MoodlewareAPI/MoodlewareClientFactory.cs
+++ b/src/Kursa.Infrastructure/MoodlewareAPI/MoodlewareClientFactory.cs
@@ -4,6 +4,9 @@ using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;
 using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Kursa.Infrastructure.MoodlewareAPI;
 
@@ -21,6 +24,17 @@ public sealed class MoodlewareClientFactory(
         var httpClient = httpClientFactory.CreateClient("Moodle");
         var authProvider = new StaticBearerTokenAuthProvider(moodleToken);
         var adapter = new HttpClientRequestAdapter(authProvider, httpClient: httpClient)
+        {
+            BaseUrl = options.Value.BridgeUrl.TrimEnd('/')
+        };
+        return new MoodlewareApiClient(adapter);
+    }
+
+    /// <summary>Creates an unauthenticated client for calling open endpoints such as POST /auth.</summary>
+    public MoodlewareApiClient CreateAnonymous()
+    {
+        var httpClient = httpClientFactory.CreateClient("Moodle");
+        var adapter = new HttpClientRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: httpClient)
         {
             BaseUrl = options.Value.BridgeUrl.TrimEnd('/')
         };

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Serialization.Json;
+using AuthRequest = Kursa.Infrastructure.MoodlewareAPI.Client.Models.AuthRequest;
 
 namespace Kursa.Infrastructure.Services;
 
@@ -22,6 +23,26 @@ public sealed class MoodleService(
 
     private static readonly TimeSpan CourseCacheDuration = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan ContentCacheDuration = TimeSpan.FromMinutes(2);
+
+    public async Task<string?> GetTokenAsync(string username, string password, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = clientFactory.CreateAnonymous();
+            var response = await client.Auth.PostAsync(new AuthRequest
+            {
+                Username = username,
+                Password = password,
+            }, cancellationToken: cancellationToken);
+
+            return response?.Token;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "MoodlewareAPI /auth failed for user {Username}", username);
+            return null;
+        }
+    }
 
     public async Task<IReadOnlyList<MoodleCourseDto>> GetEnrolledCoursesAsync(
         string moodleToken, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Users now enter their Moodle **username + password** — no raw token copying
- Backend calls MoodlewareAPI `POST /auth` (unauthenticated) → gets `wstoken` → stores it
- Added `GetTokenAsync(username, password)` to `IMoodleService` / `MoodleService`
- Added `CreateAnonymous()` to `MoodlewareClientFactory` for token-less Kiota client
- `LinkMoodleTokenCommand` now takes `Username` + `Password` instead of `Token`
- Settings page: username + password form
- Onboarding: same fix, now actually calls the API on connect

## Test plan
- [ ] Settings page shows username + password fields
- [ ] Onboarding step 2 shows username + password fields
- [ ] Submitting calls `POST /api/moodle/link` with `{ username, password }`
- [ ] Backend exchanges credentials with MoodlewareAPI and stores token

Closes #77