### PR TITLE
feat(dev): DevAuth bypass, OIDC config, proxy, courses userid fix

### DIFF
--- a/src/Kursa.API/DevAuth/DevAuthenticationHandler.cs
+++ b/src/Kursa.API/DevAuth/DevAuthenticationHandler.cs
@@ -1,0 +1,37 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Kursa.API.DevAuth;
+
+/// <summary>
+/// Used only in Development when no OIDC authority is configured.
+/// Injects a fixed dev user so all API endpoints work without a real identity provider.
+/// </summary>
+public sealed class DevAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "DevAuth";
+    public const string DevUserId = "dev-user-1";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim("sub", DevUserId),
+            new Claim(ClaimTypes.NameIdentifier, DevUserId),
+            new Claim(ClaimTypes.Name, "Dev User"),
+            new Claim(ClaimTypes.Email, "dev@kursa.local"),
+        };
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/Kursa.API/Program.cs
+++ b/src/Kursa.API/Program.cs
@@ -1,7 +1,9 @@
+using Kursa.API.DevAuth;
 using Kursa.API.Middleware;
 using Kursa.Application;
 using Kursa.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
 using Serilog;
 
 Log.Logger = new LoggerConfiguration()
@@ -20,15 +22,28 @@ try
     builder.Services.AddProblemDetails();
     builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 
-    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(options =>
-        {
-            options.Authority = builder.Configuration["Oidc:Authority"];
-            options.Audience = builder.Configuration["Oidc:ClientId"];
-            options.RequireHttpsMetadata = builder.Configuration.GetValue("Oidc:RequireHttpsMetadata", true);
-            options.TokenValidationParameters.NameClaimType = "name";
-            options.TokenValidationParameters.RoleClaimType = "role";
-        });
+    bool useDevAuth = builder.Environment.IsDevelopment()
+        && builder.Configuration.GetValue("DevAuth:Enabled", false);
+
+    if (useDevAuth)
+    {
+        Log.Warning("⚠️  No OIDC authority configured — using DevAuth bypass. DO NOT use in production.");
+        builder.Services.AddAuthentication(DevAuthenticationHandler.SchemeName)
+            .AddScheme<Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions, DevAuthenticationHandler>(
+                DevAuthenticationHandler.SchemeName, _ => { });
+    }
+    else
+    {
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.Authority = builder.Configuration["Oidc:Authority"];
+                options.Audience = builder.Configuration["Oidc:ClientId"];
+                options.RequireHttpsMetadata = builder.Configuration.GetValue("Oidc:RequireHttpsMetadata", true);
+                options.TokenValidationParameters.NameClaimType = "name";
+                options.TokenValidationParameters.RoleClaimType = "role";
+            });
+    }
 
     builder.Services.AddAuthorization();
 
@@ -36,6 +51,20 @@ try
     builder.Services.AddInfrastructure(builder.Configuration);
 
     var app = builder.Build();
+
+    // Seed dev user and apply pending migrations when running in dev-auth mode
+    if (useDevAuth)
+    {
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<Kursa.Infrastructure.Persistence.AppDbContext>();
+        await db.Database.MigrateAsync();
+
+        var userSync = scope.ServiceProvider.GetRequiredService<Kursa.Application.Common.Interfaces.IUserSyncService>();
+        await userSync.SyncUserAsync(
+            DevAuthenticationHandler.DevUserId,
+            "dev@kursa.local",
+            "Dev User");
+    }
 
     app.UseMiddleware<CorrelationIdMiddleware>();
     app.UseExceptionHandler();

--- a/src/Kursa.API/appsettings.json
+++ b/src/Kursa.API/appsettings.json
@@ -59,8 +59,8 @@
     "PyannoteUrl": "http://localhost:8002"
   },
   "Oidc": {
-    "Authority": "",
-    "ClientId": "",
+    "Authority": "https://auth.gaggao.com",
+    "ClientId": "59793f91-bdda-4425-9e5c-1bdfd9baa5b6",
     "ClientSecret": "",
     "RequireHttpsMetadata": true
   }

--- a/src/Kursa.Frontend/angular.json
+++ b/src/Kursa.Frontend/angular.json
@@ -62,7 +62,10 @@
               "buildTarget": "Kursa.Frontend:build:development"
             }
           },
-          "defaultConfiguration": "development"
+          "defaultConfiguration": "development",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          }
         },
         "test": {
           "builder": "@angular/build:unit-test"

--- a/src/Kursa.Frontend/proxy.conf.json
+++ b/src/Kursa.Frontend/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://localhost:5000",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "info"
+  }
+}

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -52,8 +52,14 @@ public sealed class MoodleService(
         if (cached is not null) return cached;
 
         var client = clientFactory.CreateForToken(moodleToken);
+
+        // Resolve the Moodle userid for this token — required by core_enrol_get_users_courses
+        var siteInfo = await GetSiteInfoAsync(moodleToken, cancellationToken);
+        var body = new CoreEnrolGetUsersCoursesRequest();
+        body.AdditionalData["userid"] = siteInfo.UserId;
+
         var result = await client.Core_enrol_get_users_courses.PostAsync(
-            new CoreEnrolGetUsersCoursesRequest(), cancellationToken: cancellationToken);
+            body, cancellationToken: cancellationToken);
 
         var courses = await DeserializeAsync<List<MoodleCourseDto>>(result, cancellationToken) ?? [];
         await SetCacheAsync(cacheKey, courses, CourseCacheDuration, cancellationToken);


### PR DESCRIPTION
## Summary
- DevAuth handler: injects dev user when `DevAuth:Enabled=true` in Development (local-only appsettings.Development.json, gitignored)
- OIDC: Authority + ClientId in appsettings.json; ClientSecret in .NET user-secrets (never committed)
- Angular proxy: `/api/*` forwarded to `http://localhost:5000` so dev server works without CORS issues
- Courses fix: `GetEnrolledCoursesAsync` now calls `GetSiteInfoAsync` first to get the actual Moodle userid (MoodlewareAPI passes userid literally, `0` returns empty)

## Test plan
- [x] 85 courses load on /courses with Moodle token connected
- [x] Settings page connects Moodle via username/password
- [x] All routes load without 401

Closes #79