### PR TITLE
fix(courses): align DTO serialization with Angular camelCase expectations

### DIFF
--- a/src/Kursa.Application/Features/Moodle/Models/MoodleDtos.cs
+++ b/src/Kursa.Application/Features/Moodle/Models/MoodleDtos.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Kursa.Application.Features.Moodle.Models;
 
 /// <summary>
@@ -7,37 +5,16 @@ namespace Kursa.Application.Features.Moodle.Models;
 /// </summary>
 public sealed record MoodleCourseDto
 {
-    [JsonPropertyName("id")]
     public int Id { get; init; }
-
-    [JsonPropertyName("shortname")]
     public string ShortName { get; init; } = string.Empty;
-
-    [JsonPropertyName("fullname")]
     public string FullName { get; init; } = string.Empty;
-
-    [JsonPropertyName("summary")]
     public string Summary { get; init; } = string.Empty;
-
-    [JsonPropertyName("startdate")]
     public long StartDate { get; init; }
-
-    [JsonPropertyName("enddate")]
     public long EndDate { get; init; }
-
-    [JsonPropertyName("visible")]
     public int Visible { get; init; } = 1;
-
-    [JsonPropertyName("courseimage")]
     public string? CourseImage { get; init; }
-
-    [JsonPropertyName("progress")]
     public double? Progress { get; init; }
-
-    [JsonPropertyName("completed")]
     public bool? Completed { get; init; }
-
-    [JsonPropertyName("category")]
     public int Category { get; init; }
 }
 
@@ -46,22 +23,11 @@ public sealed record MoodleCourseDto
 /// </summary>
 public sealed record MoodleCourseSectionDto
 {
-    [JsonPropertyName("id")]
     public int Id { get; init; }
-
-    [JsonPropertyName("name")]
     public string Name { get; init; } = string.Empty;
-
-    [JsonPropertyName("summary")]
     public string Summary { get; init; } = string.Empty;
-
-    [JsonPropertyName("section")]
     public int Section { get; init; }
-
-    [JsonPropertyName("visible")]
     public int Visible { get; init; } = 1;
-
-    [JsonPropertyName("modules")]
     public IReadOnlyList<MoodleModuleDto> Modules { get; init; } = [];
 }
 
@@ -70,28 +36,13 @@ public sealed record MoodleCourseSectionDto
 /// </summary>
 public sealed record MoodleModuleDto
 {
-    [JsonPropertyName("id")]
     public int Id { get; init; }
-
-    [JsonPropertyName("name")]
     public string Name { get; init; } = string.Empty;
-
-    [JsonPropertyName("modname")]
     public string ModName { get; init; } = string.Empty;
-
-    [JsonPropertyName("modplural")]
     public string? ModPlural { get; init; }
-
-    [JsonPropertyName("description")]
     public string? Description { get; init; }
-
-    [JsonPropertyName("url")]
     public string? Url { get; init; }
-
-    [JsonPropertyName("visible")]
     public int Visible { get; init; } = 1;
-
-    [JsonPropertyName("contents")]
     public IReadOnlyList<MoodleContentDto>? Contents { get; init; }
 }
 
@@ -100,28 +51,13 @@ public sealed record MoodleModuleDto
 /// </summary>
 public sealed record MoodleContentDto
 {
-    [JsonPropertyName("type")]
     public string Type { get; init; } = string.Empty;
-
-    [JsonPropertyName("filename")]
     public string FileName { get; init; } = string.Empty;
-
-    [JsonPropertyName("filepath")]
     public string? FilePath { get; init; }
-
-    [JsonPropertyName("filesize")]
     public long FileSize { get; init; }
-
-    [JsonPropertyName("fileurl")]
     public string? FileUrl { get; init; }
-
-    [JsonPropertyName("timecreated")]
     public long TimeCreated { get; init; }
-
-    [JsonPropertyName("timemodified")]
     public long TimeModified { get; init; }
-
-    [JsonPropertyName("mimetype")]
     public string? MimeType { get; init; }
 }
 
@@ -130,30 +66,13 @@ public sealed record MoodleContentDto
 /// </summary>
 public sealed record MoodleSiteInfoDto
 {
-    [JsonPropertyName("sitename")]
     public string SiteName { get; init; } = string.Empty;
-
-    [JsonPropertyName("username")]
     public string Username { get; init; } = string.Empty;
-
-    [JsonPropertyName("firstname")]
     public string FirstName { get; init; } = string.Empty;
-
-    [JsonPropertyName("lastname")]
     public string LastName { get; init; } = string.Empty;
-
-    [JsonPropertyName("fullname")]
     public string FullName { get; init; } = string.Empty;
-
-    [JsonPropertyName("userid")]
     public int UserId { get; init; }
-
-    [JsonPropertyName("siteurl")]
     public string SiteUrl { get; init; } = string.Empty;
-
-    [JsonPropertyName("userpictureurl")]
     public string? UserPictureUrl { get; init; }
-
-    [JsonPropertyName("lang")]
     public string? Language { get; init; }
 }

--- a/src/Kursa.Frontend/proxy.conf.json
+++ b/src/Kursa.Frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:5000",
+    "target": "http://localhost:5024",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "info"


### PR DESCRIPTION
## Summary
- Removes `[JsonPropertyName]` attributes from `MoodleDtos.cs` so ASP.NET's default camelCase policy serializes `fullName`/`shortName` correctly
- The `MoodleService` already uses `PropertyNameCaseInsensitive = true`, so deserialization from Moodle's lowercase JSON continues to work unchanged
- Fixes `proxy.conf.json` to target port 5024 (correct API port from launchSettings.json)

## Test plan
- [x] `dotnet build` passes with 0 warnings/errors
- [x] API returns `fullName`/`shortName` (camelCase) via `GET /api/moodle/courses`
- [x] Course cards display correct names in the browser (verified via Playwright)

Closes #82