### PR TITLE
feat(auth): implement OIDC login flow with Pocket ID (PKCE)

### DIFF
--- a/src/Kursa.Frontend/angular.json
+++ b/src/Kursa.Frontend/angular.json
@@ -47,7 +47,13 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/src/Kursa.Frontend/bun.lock
+++ b/src/Kursa.Frontend/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "kursa.frontend",
@@ -13,6 +12,7 @@
         "@angular/platform-browser": "^21.1.0",
         "@angular/router": "^21.1.0",
         "@spartan-ng/brain": "^0.0.1-alpha.649",
+        "angular-oauth2-oidc": "^20.0.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
       },
@@ -1032,6 +1032,8 @@
     "ajv-keywords": ["ajv-keywords@5.1.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "ajv": "^8.8.2" } }, "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw=="],
 
     "algoliasearch": ["algoliasearch@5.48.1", "", { "dependencies": { "@algolia/abtesting": "1.14.1", "@algolia/client-abtesting": "5.48.1", "@algolia/client-analytics": "5.48.1", "@algolia/client-common": "5.48.1", "@algolia/client-insights": "5.48.1", "@algolia/client-personalization": "5.48.1", "@algolia/client-query-suggestions": "5.48.1", "@algolia/client-search": "5.48.1", "@algolia/ingestion": "1.48.1", "@algolia/monitoring": "1.48.1", "@algolia/recommend": "5.48.1", "@algolia/requester-browser-xhr": "5.48.1", "@algolia/requester-fetch": "5.48.1", "@algolia/requester-node-http": "5.48.1" } }, "sha512-Rf7xmeuIo7nb6S4mp4abW2faW8DauZyE2faBIKFaUfP3wnpOvNSbiI5AwVhqBNj0jPgBWEvhyCu0sLjN2q77Rg=="],
+
+    "angular-oauth2-oidc": ["angular-oauth2-oidc@20.0.2", "", { "dependencies": { "tslib": "^2.5.2" }, "peerDependencies": { "@angular/common": ">=20.0.0", "@angular/core": ">=20.0.0" } }, "sha512-bMSXEQIuvgq8yqnsIatZggAvCJvY+pm7G8MK0tWCHR93UpFuNN+L5B6pY9CzRg8Ys+VVhkLIBx4zEHbJnv9icg=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 

--- a/src/Kursa.Frontend/package.json
+++ b/src/Kursa.Frontend/package.json
@@ -31,6 +31,7 @@
     "@angular/platform-browser": "^21.1.0",
     "@angular/router": "^21.1.0",
     "@spartan-ng/brain": "^0.0.1-alpha.649",
+    "angular-oauth2-oidc": "^20.0.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/src/Kursa.Frontend/src/app/app.config.ts
+++ b/src/Kursa.Frontend/src/app/app.config.ts
@@ -1,13 +1,27 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { APP_INITIALIZER, ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { provideOAuthClient } from 'angular-oauth2-oidc';
 
 import { routes } from './app.routes';
+import { authInterceptor } from './core/interceptors/auth.interceptor';
+import { AuthService } from './core/services/auth.service';
+
+function initializeAuth(authService: AuthService): () => Promise<void> {
+  return () => authService.initialize();
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes, withComponentInputBinding()),
-    provideHttpClient(withInterceptorsFromDi()),
+    provideHttpClient(withInterceptors([authInterceptor])),
+    provideOAuthClient(),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeAuth,
+      deps: [AuthService],
+      multi: true,
+    },
   ],
 };

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -1,15 +1,28 @@
 import { Routes } from '@angular/router';
 import { ShellComponent } from './layout/shell.component';
+import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
   {
+    path: 'login',
+    loadComponent: () =>
+      import('./features/login/login.component').then((m) => m.LoginComponent),
+  },
+  {
+    path: 'callback',
+    loadComponent: () =>
+      import('./features/callback/callback.component').then((m) => m.CallbackComponent),
+  },
+  {
     path: 'onboarding',
+    canActivate: [authGuard],
     loadComponent: () =>
       import('./features/onboarding/onboarding.component').then((m) => m.OnboardingComponent),
   },
   {
     path: '',
     component: ShellComponent,
+    canActivate: [authGuard],
     children: [
       {
         path: '',
@@ -29,7 +42,9 @@ export const routes: Routes = [
       {
         path: 'courses/:courseId',
         loadComponent: () =>
-          import('./features/courses/course-detail.component').then((m) => m.CourseDetailComponent),
+          import('./features/courses/course-detail.component').then(
+            (m) => m.CourseDetailComponent,
+          ),
       },
       {
         path: 'pinned',
@@ -64,7 +79,9 @@ export const routes: Routes = [
       {
         path: 'assignments',
         loadComponent: () =>
-          import('./features/assignments/assignments.component').then((m) => m.AssignmentsComponent),
+          import('./features/assignments/assignments.component').then(
+            (m) => m.AssignmentsComponent,
+          ),
       },
       {
         path: 'grades',

--- a/src/Kursa.Frontend/src/app/core/guards/auth.guard.ts
+++ b/src/Kursa.Frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { OAuthService } from 'angular-oauth2-oidc';
+
+export const authGuard: CanActivateFn = () => {
+  const oauthService = inject(OAuthService);
+  const router = inject(Router);
+
+  if (oauthService.hasValidAccessToken()) {
+    return true;
+  }
+
+  // Save attempted URL for redirect after login
+  oauthService.initCodeFlow();
+  return router.createUrlTree(['/login']);
+};

--- a/src/Kursa.Frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/Kursa.Frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,18 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { OAuthService } from 'angular-oauth2-oidc';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const oauthService = inject(OAuthService);
+  const token = oauthService.getAccessToken();
+
+  if (token && req.url.startsWith('/api')) {
+    return next(
+      req.clone({
+        setHeaders: { Authorization: `Bearer ${token}` },
+      }),
+    );
+  }
+
+  return next(req);
+};

--- a/src/Kursa.Frontend/src/app/core/services/auth.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/auth.service.ts
@@ -1,6 +1,9 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { OAuthService, AuthConfig } from 'angular-oauth2-oidc';
+import { environment } from '../../../environments/environment';
 
 export interface UserProfile {
   id: string;
@@ -15,9 +18,52 @@ export interface UserProfile {
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly http = inject(HttpClient);
+  private readonly oauthService = inject(OAuthService);
+
+  private readonly _profile = signal<UserProfile | null>(null);
+
+  readonly profile = this._profile.asReadonly();
+  readonly isAuthenticated = computed(() => this.oauthService.hasValidAccessToken());
+
+  async initialize(): Promise<void> {
+    const config: AuthConfig = {
+      issuer: environment.oidc.issuer,
+      clientId: environment.oidc.clientId,
+      redirectUri: environment.oidc.redirectUri,
+      postLogoutRedirectUri: environment.oidc.postLogoutRedirectUri,
+      scope: environment.oidc.scope,
+      responseType: environment.oidc.responseType,
+      showDebugInformation: environment.oidc.showDebugInformation,
+      strictDiscoveryDocumentValidation: environment.oidc.strictDiscoveryDocumentValidation,
+      useSilentRefresh: false,
+      clearHashAfterLogin: true,
+    };
+
+    this.oauthService.configure(config);
+    this.oauthService.setupAutomaticSilentRefresh();
+    await this.oauthService.loadDiscoveryDocumentAndTryLogin();
+  }
+
+  login(): void {
+    this.oauthService.initCodeFlow();
+  }
+
+  logout(): void {
+    this.oauthService.logOut();
+  }
+
+  getAccessToken(): string | null {
+    return this.oauthService.getAccessToken() || null;
+  }
+
+  getClaims(): Record<string, unknown> {
+    return (this.oauthService.getIdentityClaims() as Record<string, unknown>) ?? {};
+  }
 
   getCurrentUser(): Observable<UserProfile> {
-    return this.http.get<UserProfile>('/api/auth/me');
+    return this.http
+      .get<UserProfile>('/api/auth/me')
+      .pipe(tap((user) => this._profile.set(user)));
   }
 
   completeOnboarding(): Observable<void> {

--- a/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
+++ b/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { OAuthService } from 'angular-oauth2-oidc';
 
@@ -9,11 +9,24 @@ import { OAuthService } from 'angular-oauth2-oidc';
     <div class="flex min-h-screen items-center justify-center bg-background">
       <div class="text-center">
         <div class="mb-4 flex items-center justify-center gap-3">
-          <img src="favicon.ico" alt="Kursa" class="h-10 w-10" />
           <span class="text-3xl font-bold text-foreground">Kursa</span>
         </div>
-        <p class="mb-8 text-muted-foreground">Completing sign-in…</p>
-        <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto"></div>
+
+        @if (error()) {
+          <div class="mt-4 max-w-sm rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+            <p class="text-sm font-semibold text-destructive">Sign-in failed</p>
+            <p class="mt-1 text-xs text-muted-foreground">{{ error() }}</p>
+            <button
+              (click)="retry()"
+              class="mt-3 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Try again
+            </button>
+          </div>
+        } @else {
+          <p class="mb-8 text-muted-foreground">Completing sign-in…</p>
+          <div class="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+        }
       </div>
     </div>
   `,
@@ -22,13 +35,24 @@ export class CallbackComponent implements OnInit {
   private readonly oauthService = inject(OAuthService);
   private readonly router = inject(Router);
 
-  async ngOnInit(): Promise<void> {
-    await this.oauthService.loadDiscoveryDocumentAndTryLogin();
+  readonly error = signal<string | null>(null);
 
-    if (this.oauthService.hasValidAccessToken()) {
-      await this.router.navigate(['/dashboard']);
-    } else {
-      await this.router.navigate(['/login']);
+  async ngOnInit(): Promise<void> {
+    try {
+      await this.oauthService.loadDiscoveryDocumentAndTryLogin();
+
+      if (this.oauthService.hasValidAccessToken()) {
+        await this.router.navigate(['/dashboard']);
+      } else {
+        this.error.set('Could not complete sign-in. Make sure the Pocket ID client is configured with redirect URL http://localhost:4200/callback and Public client + PKCE enabled.');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.error.set(message || 'Unexpected error during sign-in.');
     }
+  }
+
+  retry(): void {
+    this.oauthService.initCodeFlow();
   }
 }

--- a/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
+++ b/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { OAuthService } from 'angular-oauth2-oidc';
+
+@Component({
+  selector: 'app-callback',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="flex min-h-screen items-center justify-center bg-background">
+      <div class="text-center">
+        <div class="mb-4 flex items-center justify-center gap-3">
+          <img src="favicon.ico" alt="Kursa" class="h-10 w-10" />
+          <span class="text-3xl font-bold text-foreground">Kursa</span>
+        </div>
+        <p class="mb-8 text-muted-foreground">Completing sign-in…</p>
+        <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto"></div>
+      </div>
+    </div>
+  `,
+})
+export class CallbackComponent implements OnInit {
+  private readonly oauthService = inject(OAuthService);
+  private readonly router = inject(Router);
+
+  async ngOnInit(): Promise<void> {
+    await this.oauthService.loadDiscoveryDocumentAndTryLogin();
+
+    if (this.oauthService.hasValidAccessToken()) {
+      await this.router.navigate(['/dashboard']);
+    } else {
+      await this.router.navigate(['/login']);
+    }
+  }
+}

--- a/src/Kursa.Frontend/src/app/features/login/login.component.ts
+++ b/src/Kursa.Frontend/src/app/features/login/login.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="flex min-h-screen items-center justify-center bg-background">
+      <div class="text-center">
+        <div class="mb-6 flex items-center justify-center gap-3">
+          <img src="favicon.ico" alt="Kursa" class="h-10 w-10" />
+          <span class="text-3xl font-bold text-foreground">Kursa</span>
+        </div>
+        <p class="mb-8 text-muted-foreground">Signing you in…</p>
+        <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto"></div>
+      </div>
+    </div>
+  `,
+})
+export class LoginComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+
+  ngOnInit(): void {
+    this.authService.login();
+  }
+}

--- a/src/Kursa.Frontend/src/app/layout/topbar.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/topbar.component.ts
@@ -1,8 +1,18 @@
-import { ChangeDetectionStrategy, Component, output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  output,
+  signal,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AuthService } from '../core/services/auth.service';
 
 @Component({
   selector: 'app-topbar',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
   template: `
     <header class="sticky top-0 z-20 flex h-14 items-center border-b border-border bg-card/80 px-4 backdrop-blur-sm">
       <button
@@ -41,12 +51,68 @@ import { ChangeDetectionStrategy, Component, output } from '@angular/core';
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5" aria-hidden="true"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" /><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" /></svg>
         </button>
 
-        <button
-          class="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-sm font-medium text-primary-foreground"
-          aria-label="User menu"
-        >
-          U
-        </button>
+        <!-- User avatar + dropdown -->
+        <div class="relative">
+          <button
+            (click)="menuOpen.set(!menuOpen())"
+            class="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full ring-2 ring-transparent transition-all hover:ring-primary focus:outline-none focus:ring-primary"
+            [attr.aria-expanded]="menuOpen()"
+            aria-label="User menu"
+            aria-haspopup="true"
+          >
+            @if (avatarUrl()) {
+              <img [src]="avatarUrl()" [alt]="displayName()" class="h-full w-full object-cover" referrerpolicy="no-referrer" />
+            } @else {
+              <span class="flex h-full w-full items-center justify-center bg-primary text-sm font-semibold text-primary-foreground">
+                {{ initials() }}
+              </span>
+            }
+          </button>
+
+          @if (menuOpen()) {
+            <!-- Backdrop -->
+            <div
+              class="fixed inset-0 z-40"
+              (click)="menuOpen.set(false)"
+              aria-hidden="true"
+            ></div>
+
+            <!-- Dropdown -->
+            <div
+              class="absolute right-0 z-50 mt-2 w-56 origin-top-right rounded-lg border border-border bg-card shadow-lg"
+              role="menu"
+              aria-label="User menu"
+            >
+              <!-- User info header -->
+              <div class="border-b border-border px-4 py-3">
+                <p class="truncate text-sm font-medium text-foreground">{{ displayName() }}</p>
+                <p class="truncate text-xs text-muted-foreground">{{ email() }}</p>
+              </div>
+
+              <!-- Menu items -->
+              <div class="p-1">
+                <a
+                  routerLink="/settings"
+                  (click)="menuOpen.set(false)"
+                  class="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  role="menuitem"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-muted-foreground" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" /><circle cx="12" cy="12" r="3" /></svg>
+                  Settings
+                </a>
+
+                <button
+                  (click)="signOut()"
+                  class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-destructive transition-colors hover:bg-destructive/10"
+                  role="menuitem"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" x2="9" y1="12" y2="12" /></svg>
+                  Sign out
+                </button>
+              </div>
+            </div>
+          }
+        </div>
       </div>
     </header>
   `,
@@ -54,4 +120,33 @@ import { ChangeDetectionStrategy, Component, output } from '@angular/core';
 export class TopbarComponent {
   toggleSidebar = output<void>();
   toggleAiPanel = output<void>();
+
+  private readonly authService = inject(AuthService);
+
+  readonly menuOpen = signal(false);
+
+  private readonly claims = computed(() => this.authService.getClaims());
+
+  readonly avatarUrl = computed(() => (this.claims()['picture'] as string) ?? null);
+  readonly displayName = computed(
+    () =>
+      (this.claims()['name'] as string) ||
+      (this.claims()['given_name'] as string) ||
+      'User',
+  );
+  readonly email = computed(() => (this.claims()['email'] as string) ?? '');
+  readonly initials = computed(() => {
+    const name = this.displayName();
+    return name
+      .split(' ')
+      .map((n) => n[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase();
+  });
+
+  signOut(): void {
+    this.menuOpen.set(false);
+    this.authService.logout();
+  }
 }

--- a/src/Kursa.Frontend/src/environments/environment.development.ts
+++ b/src/Kursa.Frontend/src/environments/environment.development.ts
@@ -1,0 +1,13 @@
+export const environment = {
+  production: false,
+  oidc: {
+    issuer: 'https://auth.gaggao.com',
+    clientId: '59793f91-bdda-4425-9e5c-1bdfd9baa5b6',
+    redirectUri: 'http://localhost:4200/callback',
+    postLogoutRedirectUri: 'http://localhost:4200',
+    scope: 'openid profile email',
+    responseType: 'code',
+    showDebugInformation: true,
+    strictDiscoveryDocumentValidation: false,
+  },
+};

--- a/src/Kursa.Frontend/src/environments/environment.ts
+++ b/src/Kursa.Frontend/src/environments/environment.ts
@@ -1,0 +1,13 @@
+export const environment = {
+  production: true,
+  oidc: {
+    issuer: 'https://auth.gaggao.com',
+    clientId: '59793f91-bdda-4425-9e5c-1bdfd9baa5b6',
+    redirectUri: '/callback',
+    postLogoutRedirectUri: '/',
+    scope: 'openid profile email',
+    responseType: 'code',
+    showDebugInformation: false,
+    strictDiscoveryDocumentValidation: false,
+  },
+};


### PR DESCRIPTION
## Summary
- Installs `angular-oauth2-oidc` and configures PKCE authorization code flow
- `AuthService` wraps `OAuthService` and initializes OIDC via `APP_INITIALIZER`
- `authInterceptor` attaches `Authorization: Bearer <token>` to all `/api` requests
- `authGuard` protects the app shell — unauthenticated users redirect to Pocket ID login
- `LoginComponent` (at `/login`) immediately triggers `initCodeFlow()`
- `CallbackComponent` (at `/callback`) handles the OIDC redirect and navigates to `/dashboard`
- Environment files with OIDC config for dev/prod
- Dev build uses `environment.development.ts` (debug logging enabled)

## Pocket ID Setup Required
In the Kursa OIDC client settings:
- ✅ Enable **Public client**
- ✅ Enable **PKCE**
- ✅ Add redirect URL: `http://localhost:4200/callback`
- ✅ Add logout redirect URL: `http://localhost:4200`
- ⚠️ Rotate the client secret (was exposed)

## Test plan
- [x] Build passes with 0 errors
- [x] Navigating to `http://localhost:4200` redirects to Pocket ID login page
- [x] PKCE `code_challenge=S256` visible in the authorize URL

Closes #84