### PR TITLE
fix(auth): prevent app crash on /callback when token exchange fails

### DIFF
--- a/src/Kursa.Frontend/src/app/core/services/auth.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/auth.service.ts
@@ -41,7 +41,25 @@ export class AuthService {
 
     this.oauthService.configure(config);
     this.oauthService.setupAutomaticSilentRefresh();
-    await this.oauthService.loadDiscoveryDocumentAndTryLogin();
+
+    // Only load the discovery document — do NOT try to exchange auth codes.
+    // The CallbackComponent handles the actual code exchange via handleCallback().
+    // If we called loadDiscoveryDocumentAndTryLogin() here and the token exchange
+    // failed (e.g. Pocket ID misconfigured), the app would crash before rendering.
+    try {
+      await this.oauthService.loadDiscoveryDocument();
+    } catch {
+      // Non-fatal: app still renders the login page even without discovery doc.
+    }
+  }
+
+  async handleCallback(): Promise<boolean> {
+    try {
+      await this.oauthService.tryLogin();
+      return this.oauthService.hasValidAccessToken();
+    } catch {
+      return false;
+    }
   }
 
   login(): void {

--- a/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
+++ b/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { OAuthService } from 'angular-oauth2-oidc';
+import { AuthService } from '../../core/services/auth.service';
 
 @Component({
   selector: 'app-callback',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex min-h-screen items-center justify-center bg-background">
-      <div class="text-center">
+      <div class="text-center px-4">
         <div class="mb-4 flex items-center justify-center gap-3">
           <span class="text-3xl font-bold text-foreground">Kursa</span>
         </div>
@@ -32,27 +32,25 @@ import { OAuthService } from 'angular-oauth2-oidc';
   `,
 })
 export class CallbackComponent implements OnInit {
-  private readonly oauthService = inject(OAuthService);
+  private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
 
   readonly error = signal<string | null>(null);
 
   async ngOnInit(): Promise<void> {
-    try {
-      await this.oauthService.loadDiscoveryDocumentAndTryLogin();
-
-      if (this.oauthService.hasValidAccessToken()) {
-        await this.router.navigate(['/dashboard']);
-      } else {
-        this.error.set('Could not complete sign-in. Make sure the Pocket ID client is configured with redirect URL http://localhost:4200/callback and Public client + PKCE enabled.');
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.error.set(message || 'Unexpected error during sign-in.');
+    const success = await this.authService.handleCallback();
+    if (success) {
+      await this.router.navigate(['/dashboard']);
+    } else {
+      this.error.set(
+        'Sign-in failed. Make sure the Pocket ID client has redirect URL ' +
+          window.location.origin +
+          '/callback registered, and that Public client + PKCE are enabled.',
+      );
     }
   }
 
   retry(): void {
-    this.oauthService.initCodeFlow();
+    this.authService.login();
   }
 }


### PR DESCRIPTION
## Summary
- `APP_INITIALIZER` now only calls `loadDiscoveryDocument()` (wrapped in try/catch, non-fatal)
- `CallbackComponent` uses `AuthService.handleCallback()` → `tryLogin()` for the actual code exchange
- A failed token exchange now shows a proper error message instead of a black screen / crashed app

## Test plan
- [x] Build passes 0 errors
- [x] Login flow works end-to-end (tested via Playwright)
- [x] Profile picture and dropdown working

Closes #87