### PR TITLE
feat(llm): migrate AI stack to OpenRouter as primary cloud provider

### DIFF
--- a/src/Kursa.API/appsettings.json
+++ b/src/Kursa.API/appsettings.json
@@ -38,10 +38,11 @@
     "BridgeUrl": "http://localhost:8000"
   },
   "Llm": {
-    "Provider": "openai",
+    "Provider": "openrouter",
     "ApiKey": "",
-    "Model": "gpt-4o-mini",
-    "EmbeddingModel": "text-embedding-3-small",
+    "Model": "anthropic/claude-haiku-4-5",
+    "EmbeddingModel": "nomic-embed-text",
+    "OpenRouterBaseUrl": "https://openrouter.ai/api/v1",
     "OllamaHost": "http://localhost:11434",
     "MaxRetries": 3,
     "TimeoutSeconds": 60

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -99,10 +99,10 @@ public static class DependencyInjection
 
             return llmOptions.Provider.ToLowerInvariant() switch
             {
-                "openai" or "anthropic" => ActivatorUtilities.CreateInstance<OpenAiLlmProvider>(sp),
+                "openrouter" => ActivatorUtilities.CreateInstance<OpenRouterLlmProvider>(sp),
                 "ollama" => ActivatorUtilities.CreateInstance<OllamaLlmProvider>(sp),
                 _ => throw new InvalidOperationException(
-                    $"Unknown LLM provider '{llmOptions.Provider}'. Supported: openai, anthropic, ollama.")
+                    $"Unknown LLM provider '{llmOptions.Provider}'. Supported: openrouter, ollama.")
             };
         });
 

--- a/src/Kursa.Infrastructure/Options/LlmOptions.cs
+++ b/src/Kursa.Infrastructure/Options/LlmOptions.cs
@@ -11,9 +11,12 @@ public sealed class LlmOptions
 
     public string ApiKey { get; init; } = string.Empty;
 
-    public string Model { get; init; } = "gpt-4o-mini";
+    public string Model { get; init; } = "anthropic/claude-haiku-4-5";
 
-    public string EmbeddingModel { get; init; } = "text-embedding-3-small";
+    /// <summary>Embedding model served by Ollama (used as embedding backend for all providers).</summary>
+    public string EmbeddingModel { get; init; } = "nomic-embed-text";
+
+    public string OpenRouterBaseUrl { get; init; } = "https://openrouter.ai/api/v1";
 
     public string OllamaHost { get; init; } = "http://localhost:11434";
 

--- a/src/Kursa.Infrastructure/Services/OpenRouterLlmProvider.cs
+++ b/src/Kursa.Infrastructure/Services/OpenRouterLlmProvider.cs
@@ -1,26 +1,46 @@
+using System.ClientModel;
 using Kursa.Application.Common.Interfaces;
 using Kursa.Infrastructure.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenAI;
 using OpenAI.Chat;
 using OpenAI.Embeddings;
 
 namespace Kursa.Infrastructure.Services;
 
-public sealed class OpenAiLlmProvider : ILlmProvider
+/// <summary>
+/// LLM provider that routes chat completions through OpenRouter (OpenAI-compatible API).
+/// Embeddings are handled via Ollama since OpenRouter does not natively support them.
+/// </summary>
+public sealed class OpenRouterLlmProvider : ILlmProvider
 {
     private readonly ChatClient _chatClient;
     private readonly EmbeddingClient _embeddingClient;
-    private readonly ILogger<OpenAiLlmProvider> _logger;
+    private readonly ILogger<OpenRouterLlmProvider> _logger;
 
-    public OpenAiLlmProvider(IOptions<LlmOptions> options, ILogger<OpenAiLlmProvider> logger)
+    public OpenRouterLlmProvider(IOptions<LlmOptions> options, ILogger<OpenRouterLlmProvider> logger)
     {
         _logger = logger;
         LlmOptions llmOptions = options.Value;
 
-        string apiKey = llmOptions.ApiKey;
-        _chatClient = new ChatClient(llmOptions.Model, apiKey);
-        _embeddingClient = new EmbeddingClient(llmOptions.EmbeddingModel, apiKey);
+        // OpenRouter exposes an OpenAI-compatible chat API
+        var openRouterOptions = new OpenAIClientOptions
+        {
+            Endpoint = new Uri(llmOptions.OpenRouterBaseUrl)
+        };
+        var openRouterCredential = new ApiKeyCredential(llmOptions.ApiKey);
+        var openRouterClient = new OpenAIClient(openRouterCredential, openRouterOptions);
+        _chatClient = openRouterClient.GetChatClient(llmOptions.Model);
+
+        // OpenRouter does not support embeddings — use Ollama for embeddings
+        var ollamaOptions = new OpenAIClientOptions
+        {
+            Endpoint = new Uri(llmOptions.OllamaHost)
+        };
+        var ollamaCredential = new ApiKeyCredential("ollama");
+        var ollamaClient = new OpenAIClient(ollamaCredential, ollamaOptions);
+        _embeddingClient = ollamaClient.GetEmbeddingClient(llmOptions.EmbeddingModel);
     }
 
     public async Task<LlmChatResponse> ChatAsync(
@@ -52,15 +72,15 @@ public sealed class OpenAiLlmProvider : ILlmProvider
             chatOptions.MaxOutputTokenCount = request.MaxTokens.Value;
         }
 
-        _logger.LogDebug("Sending chat request with {MessageCount} messages", messages.Count);
+        _logger.LogDebug("Sending OpenRouter chat request with {MessageCount} messages", messages.Count);
 
         ChatCompletion completion = await _chatClient.CompleteChatAsync(messages, chatOptions, cancellationToken);
 
         return new LlmChatResponse
         {
             Content = completion.Content[0].Text,
-            PromptTokens = completion.Usage.InputTokenCount,
-            CompletionTokens = completion.Usage.OutputTokenCount,
+            PromptTokens = completion.Usage?.InputTokenCount ?? 0,
+            CompletionTokens = completion.Usage?.OutputTokenCount ?? 0,
         };
     }
 
@@ -68,7 +88,7 @@ public sealed class OpenAiLlmProvider : ILlmProvider
         string text,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Generating embedding for text of length {Length}", text.Length);
+        _logger.LogDebug("Generating embedding via Ollama for text of length {Length}", text.Length);
 
         OpenAIEmbedding embedding = await _embeddingClient.GenerateEmbeddingAsync(text, cancellationToken: cancellationToken);
         ReadOnlyMemory<float> vector = embedding.ToFloats();
@@ -80,7 +100,7 @@ public sealed class OpenAiLlmProvider : ILlmProvider
         IReadOnlyList<string> texts,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Generating embeddings for {Count} texts", texts.Count);
+        _logger.LogDebug("Generating embeddings via Ollama for {Count} texts", texts.Count);
 
         OpenAIEmbeddingCollection embeddings = await _embeddingClient.GenerateEmbeddingsAsync(texts, cancellationToken: cancellationToken);
 


### PR DESCRIPTION
## Summary
- Replace `OpenAiLlmProvider` with `OpenRouterLlmProvider` using the OpenAI-compatible API at `https://openrouter.ai/api/v1`
- Chat completions go through OpenRouter; embeddings use Ollama as backend (OpenRouter has no native embedding support)
- Default model: `anthropic/claude-haiku-4-5`; embedding model: `nomic-embed-text` (via Ollama)
- Supported providers are now `openrouter` and `ollama` only — OpenAI/Anthropic removed as direct providers

## Test plan
- [ ] Build passes: `dotnet build`
- [ ] Set `Llm:ApiKey` to OpenRouter API key and `Llm:Provider` to `openrouter` in appsettings/user-secrets
- [ ] Ensure Ollama is running with `nomic-embed-text` pulled for embeddings
- [ ] Verify chat features call through OpenRouter
- [ ] Verify `ollama` provider still works standalone

Closes #91