### PR TITLE
fix(qdrant): return empty results when collection does not exist yet

### DIFF
--- a/src/Kursa.Infrastructure/Options/LlmOptions.cs
+++ b/src/Kursa.Infrastructure/Options/LlmOptions.cs
@@ -18,7 +18,8 @@ public sealed class LlmOptions
 
     public string OpenRouterBaseUrl { get; init; } = "https://openrouter.ai/api/v1";
 
-    public string OllamaHost { get; init; } = "http://localhost:11434";
+    /// <summary>Must include the /v1 path — e.g. http://localhost:11434/v1 or https://your-ollama/v1</summary>
+    public string OllamaHost { get; init; } = "http://localhost:11434/v1";
 
     public int MaxRetries { get; init; } = 3;
 

--- a/src/Kursa.Infrastructure/Services/QdrantVectorStore.cs
+++ b/src/Kursa.Infrastructure/Services/QdrantVectorStore.cs
@@ -92,12 +92,21 @@ public sealed class QdrantVectorStore : IVectorStore
             filter = MatchKeyword("content_id", filterByContentId.Value.ToString());
         }
 
-        IReadOnlyList<ScoredPoint> results = await _client.SearchAsync(
-            collectionName,
-            queryVector.ToArray(),
-            filter: filter,
-            limit: (ulong)limit,
-            cancellationToken: cancellationToken);
+        IReadOnlyList<ScoredPoint> results;
+        try
+        {
+            results = await _client.SearchAsync(
+                collectionName,
+                queryVector.ToArray(),
+                filter: filter,
+                limit: (ulong)limit,
+                cancellationToken: cancellationToken);
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            _logger.LogDebug("Qdrant collection '{Collection}' does not exist yet — returning empty results", collectionName);
+            return [];
+        }
 
         return results.Select(r => new VectorSearchResult
         {


### PR DESCRIPTION
## Summary
- Catch gRPC `NotFound` when searching a Qdrant collection that hasn't been created yet
- Returns empty results instead of crashing — allows chat/RAG to work before any content is pinned
- Also documents that `OllamaHost` must include the `/v1` path (OpenAI SDK appends paths directly without adding `/v1`)

## Test plan
- [ ] Send a chat message with no pinned content → should get an AI response (no context, not a 500)
- [ ] Pin content, then chat → RAG results should be included

Closes #95