### PR TITLE
fix(moodle): fix course content 500 error and error display

### DIFF
--- a/src/Kursa.Application/Features/Moodle/Models/MoodleDtos.cs
+++ b/src/Kursa.Application/Features/Moodle/Models/MoodleDtos.cs
@@ -54,10 +54,10 @@ public sealed record MoodleContentDto
     public string Type { get; init; } = string.Empty;
     public string FileName { get; init; } = string.Empty;
     public string? FilePath { get; init; }
-    public long FileSize { get; init; }
+    public double FileSize { get; init; }
     public string? FileUrl { get; init; }
-    public long TimeCreated { get; init; }
-    public long TimeModified { get; init; }
+    public double? TimeCreated { get; init; }
+    public double? TimeModified { get; init; }
     public string? MimeType { get; init; }
 }
 

--- a/src/Kursa.Application/Features/Moodle/Queries/GetCourseContent.cs
+++ b/src/Kursa.Application/Features/Moodle/Queries/GetCourseContent.cs
@@ -38,9 +38,16 @@ public sealed class GetCourseContentHandler(
         if (string.IsNullOrEmpty(user.MoodleToken))
             return Result<IReadOnlyList<MoodleCourseSectionDto>>.Failure("Moodle account is not linked.");
 
-        var sections = await moodleService.GetCourseContentAsync(
-            user.MoodleToken, request.MoodleCourseId, cancellationToken);
+        try
+        {
+            var sections = await moodleService.GetCourseContentAsync(
+                user.MoodleToken, request.MoodleCourseId, cancellationToken);
 
-        return Result<IReadOnlyList<MoodleCourseSectionDto>>.Success(sections);
+            return Result<IReadOnlyList<MoodleCourseSectionDto>>.Success(sections);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Result<IReadOnlyList<MoodleCourseSectionDto>>.Failure(ex.Message);
+        }
     }
 }

--- a/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
+++ b/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
@@ -142,7 +142,10 @@ export class CourseDetailComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        this.error.set(err.error ?? 'Failed to load course content.');
+        const detail = typeof err.error === 'string'
+          ? err.error
+          : (err.error?.detail ?? err.error?.title ?? err.message ?? 'Failed to load course content.');
+        this.error.set(detail);
         this.loading.set(false);
       },
     });

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -74,10 +74,22 @@ public sealed class MoodleService(
         if (cached is not null) return cached;
 
         var client = clientFactory.CreateForToken(moodleToken);
-        var result = await client.Core_course_get_contents.PostAsync(
+        UntypedNode? result = await client.Core_course_get_contents.PostAsync(
             new CoreCourseGetContentsRequest { Courseid = courseId }, cancellationToken: cancellationToken);
 
-        var sections = await DeserializeAsync<List<MoodleCourseSectionDto>>(result, cancellationToken) ?? [];
+        ThrowIfMoodleError(result, "core_course_get_contents");
+
+        List<MoodleCourseSectionDto> sections;
+        try
+        {
+            sections = await DeserializeAsync<List<MoodleCourseSectionDto>>(result, cancellationToken) ?? [];
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to deserialize course content for course {CourseId}", courseId);
+            throw new InvalidOperationException($"Failed to parse course content response: {ex.Message}", ex);
+        }
+
         await SetCacheAsync(cacheKey, sections, ContentCacheDuration, cancellationToken);
         return sections;
     }
@@ -240,4 +252,25 @@ public sealed class MoodleService(
 
     private static string HashToken(string token)
         => token.GetHashCode(StringComparison.Ordinal).ToString("x8");
+
+    /// <summary>
+    /// Detects Moodle error responses (HTTP 200 with an exception/errorcode body) and throws
+    /// an <see cref="InvalidOperationException"/> with the Moodle error message so callers
+    /// don't try to deserialize error objects as content DTOs.
+    /// </summary>
+    private static void ThrowIfMoodleError(UntypedNode? node, string operation)
+    {
+        if (node is not UntypedObject obj) return;
+
+        IDictionary<string, UntypedNode?> values = obj.GetValue()!;
+        if (!values.ContainsKey("exception")) return;
+
+        string message = "Moodle error";
+        if (values.TryGetValue("message", out UntypedNode? msgNode) && msgNode is UntypedString msgStr)
+            message = msgStr.GetValue() ?? message;
+        else if (values.TryGetValue("errorcode", out UntypedNode? codeNode) && codeNode is UntypedString codeStr)
+            message = codeStr.GetValue() ?? message;
+
+        throw new InvalidOperationException($"Moodle returned an error for '{operation}': {message}");
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `MoodleContentDto` timestamps (`TimeCreated`, `TimeModified`) and `FileSize` to `double`/`double?` — Moodle returns them as floating-point numbers, causing `JsonException` when deserializing to `long`
- Add `ThrowIfMoodleError` helper to detect Moodle error objects (HTTP 200 with `exception` body) before attempting deserialization
- Catch `InvalidOperationException` in `GetCourseContentHandler` and return `Result.Failure` (400) instead of unhandled 500
- Fix frontend error display: handle both string and `ProblemDetails` error shapes (fixes `[object Object]` shown to users)

## Test plan
- [ ] Navigate to any course detail page — sections and modules load correctly
- [ ] File sizes display correctly (KB)
- [ ] "Open", "Start quiz", "View task" buttons appear for appropriate module types
- [ ] Error state shows readable message if Moodle returns an error

Closes #103