### PR TITLE
fix(moodle): proxy pluginfile.php downloads through backend

### DIFF
--- a/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
+++ b/src/Kursa.Application/Common/Interfaces/IMoodleService.cs
@@ -32,4 +32,11 @@ public interface IMoodleService
     Task<MoodleCalendarEventsResponseDto> GetCalendarEventsAsync(
         string moodleToken, long timeStart, long timeEnd,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches a Moodle pluginfile.php resource by appending the token to the URL.
+    /// Returns the raw HTTP response so the caller can stream it to the client.
+    /// </summary>
+    Task<HttpResponseMessage> GetFileAsync(
+        string moodleToken, string moodleFileUrl, CancellationToken cancellationToken = default);
 }

--- a/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
+++ b/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
@@ -168,7 +168,16 @@ export class CourseDetailComponent implements OnInit {
   }
 
   primaryFileUrl(mod: MoodleModule): string | null {
-    return mod.contents?.find(c => c.fileUrl)?.fileUrl ?? null;
+    const raw = mod.contents?.find(c => c.fileUrl)?.fileUrl ?? null;
+    return raw ? this.proxyFileUrl(raw) : null;
+  }
+
+  /** Routes Moodle pluginfile.php URLs through the backend proxy to inject the auth token. */
+  proxyFileUrl(url: string): string {
+    if (url.includes('pluginfile.php')) {
+      return `/api/moodle/file?url=${encodeURIComponent(url)}`;
+    }
+    return url;
   }
 
   modLabel(modName: string): string {

--- a/src/Kursa.Infrastructure/DependencyInjection.cs
+++ b/src/Kursa.Infrastructure/DependencyInjection.cs
@@ -33,6 +33,8 @@ public static class DependencyInjection
 
         // Moodle bridge — Kiota-generated client via MoodlewareAPI
         services.AddHttpClient("Moodle");
+        // Direct Moodle file downloads (pluginfile.php proxy)
+        services.AddHttpClient("MoodleFile");
         services.AddSingleton<MoodlewareClientFactory>();
         services.AddScoped<IMoodleService, MoodleService>();
 

--- a/src/Kursa.Infrastructure/Services/MoodleService.cs
+++ b/src/Kursa.Infrastructure/Services/MoodleService.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Text.Json;
 using Kursa.Application.Common.Interfaces;
 using Kursa.Application.Features.Moodle.Models;
@@ -13,6 +14,7 @@ namespace Kursa.Infrastructure.Services;
 
 public sealed class MoodleService(
     MoodlewareClientFactory clientFactory,
+    IHttpClientFactory httpClientFactory,
     IDistributedCache cache,
     ILogger<MoodleService> logger) : IMoodleService
 {
@@ -195,6 +197,23 @@ public sealed class MoodleService(
         var dto = await DeserializeAsync<MoodleCalendarEventsResponseDto>(result, cancellationToken) ?? new MoodleCalendarEventsResponseDto();
         await SetCacheAsync(cacheKey, dto, ContentCacheDuration, cancellationToken);
         return dto;
+    }
+
+    public async Task<HttpResponseMessage> GetFileAsync(
+        string moodleToken, string moodleFileUrl, CancellationToken cancellationToken = default)
+    {
+        // Append token as a query parameter — Moodle pluginfile.php supports ?token=<wstoken>
+        var uri = new UriBuilder(moodleFileUrl);
+        string query = string.IsNullOrEmpty(uri.Query)
+            ? $"token={Uri.EscapeDataString(moodleToken)}"
+            : $"{uri.Query.TrimStart('?')}&token={Uri.EscapeDataString(moodleToken)}";
+        uri.Query = query;
+
+        HttpClient client = httpClientFactory.CreateClient("MoodleFile");
+        HttpResponseMessage response = await client.GetAsync(
+            uri.Uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        return response;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add `IMoodleService.GetFileAsync` — fetches Moodle file by appending `?token=<wstoken>` to URL, streams response via dedicated `MoodleFile` named HttpClient
- Add `GET /api/moodle/file?url=<encoded>` endpoint — looks up user's stored Moodle token, proxies the file with correct Content-Type and Content-Disposition headers
- Update course-detail frontend — `Open` buttons for `pluginfile.php` URLs now route through `/api/moodle/file` proxy; token never exposed to browser

## Test plan
- [ ] Click "Open" on a file resource in course detail → file downloads correctly
- [ ] Moodle token is NOT visible in the browser URL bar
- [ ] Non-pluginfile URLs (quiz, assignment, forum links) still open directly

Closes #106