### PR TITLE
feat(rag): pin Moodle modules for AI indexing

### DIFF
--- a/src/Kursa.API/Controllers/PinnedContentsController.cs
+++ b/src/Kursa.API/Controllers/PinnedContentsController.cs
@@ -60,6 +60,41 @@ public class PinnedContentsController(ISender sender) : ControllerBase
             ? Ok()
             : BadRequest(result.Error);
     }
+
+    /// <summary>
+    /// Lazily pins a Moodle module by creating the local Course/Module/Content hierarchy
+    /// and triggering RAG indexing in the background.
+    /// </summary>
+    [HttpPost("moodle")]
+    public async Task<IActionResult> PinMoodleModuleAsync(
+        [FromBody] PinMoodleModuleRequest request, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new PinMoodleModuleCommand(
+            request.MoodleCourseId,
+            request.CourseName,
+            request.CourseShortName,
+            request.MoodleModuleId,
+            request.ModuleName,
+            request.ModType,
+            request.Description,
+            request.Url,
+            request.FileUrl), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.Error);
+    }
 }
 
 public sealed record PinContentRequest(string? Notes);
+
+public sealed record PinMoodleModuleRequest(
+    int MoodleCourseId,
+    string CourseName,
+    string CourseShortName,
+    int MoodleModuleId,
+    string ModuleName,
+    string ModType,
+    string? Description,
+    string? Url,
+    string? FileUrl);

--- a/src/Kursa.Application/Features/PinnedContents/Commands/PinMoodleModule.cs
+++ b/src/Kursa.Application/Features/PinnedContents/Commands/PinMoodleModule.cs
@@ -1,0 +1,161 @@
+using FluentValidation;
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using Kursa.Domain.Entities;
+using Kursa.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kursa.Application.Features.PinnedContents.Commands;
+
+/// <summary>
+/// Pins a Moodle module/resource by lazily creating the local Course → Module → Content
+/// hierarchy and scheduling it for RAG indexing. Returns immediately; indexing runs in
+/// the background so the response is fast even for large content.
+/// </summary>
+public sealed record PinMoodleModuleCommand(
+    int MoodleCourseId,
+    string CourseName,
+    string CourseShortName,
+    int MoodleModuleId,
+    string ModuleName,
+    string ModType,
+    string? Description,
+    string? Url,
+    string? FileUrl
+) : IRequest<Result<PinMoodleModuleResponseDto>>;
+
+public sealed record PinMoodleModuleResponseDto(Guid ContentId, bool AlreadyIndexed);
+
+public sealed class PinMoodleModuleValidator : AbstractValidator<PinMoodleModuleCommand>
+{
+    public PinMoodleModuleValidator()
+    {
+        RuleFor(x => x.MoodleCourseId).GreaterThan(0);
+        RuleFor(x => x.CourseName).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.MoodleModuleId).GreaterThan(0);
+        RuleFor(x => x.ModuleName).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.ModType).NotEmpty().MaximumLength(100);
+    }
+}
+
+public sealed class PinMoodleModuleHandler(
+    ICurrentUserService currentUserService,
+    IAppDbContext dbContext,
+    IContentPipeline contentPipeline,
+    ILogger<PinMoodleModuleHandler> logger) : IRequestHandler<PinMoodleModuleCommand, Result<PinMoodleModuleResponseDto>>
+{
+    public async Task<Result<PinMoodleModuleResponseDto>> Handle(
+        PinMoodleModuleCommand request, CancellationToken cancellationToken)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.ExternalId is null)
+            return Result<PinMoodleModuleResponseDto>.Failure("User is not authenticated.");
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalId == currentUserService.ExternalId, cancellationToken);
+
+        if (user is null)
+            return Result<PinMoodleModuleResponseDto>.Failure("User not found.");
+
+        // --- 1. Find or create Course ---
+        Course? course = await dbContext.Courses
+            .FirstOrDefaultAsync(c => c.MoodleCourseId == request.MoodleCourseId, cancellationToken);
+
+        if (course is null)
+        {
+            course = new Course
+            {
+                Name = request.CourseName,
+                ShortName = request.CourseShortName,
+                MoodleCourseId = request.MoodleCourseId,
+            };
+            dbContext.Courses.Add(course);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        // --- 2. Find or create Module ---
+        Module? module = await dbContext.Modules
+            .FirstOrDefaultAsync(m => m.MoodleModuleId == request.MoodleModuleId && m.CourseId == course.Id, cancellationToken);
+
+        if (module is null)
+        {
+            module = new Module
+            {
+                Name = request.ModuleName,
+                MoodleModuleId = request.MoodleModuleId,
+                CourseId = course.Id,
+            };
+            dbContext.Modules.Add(module);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        // --- 3. Find or create Content ---
+        Content? content = await dbContext.Contents
+            .FirstOrDefaultAsync(c => c.MoodleContentId == request.MoodleModuleId && c.ModuleId == module.Id, cancellationToken);
+
+        if (content is null)
+        {
+            content = new Content
+            {
+                Title = request.ModuleName,
+                Description = request.Description,
+                Type = MapContentType(request.ModType, request.FileUrl),
+                Url = request.FileUrl ?? request.Url,
+                MoodleContentId = request.MoodleModuleId,
+                ModuleId = module.Id,
+            };
+            dbContext.Contents.Add(content);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        // --- 4. Pin the content ---
+        PinnedContent? pinned = await dbContext.PinnedContents
+            .FirstOrDefaultAsync(p => p.ContentId == content.Id && p.UserId == user.Id, cancellationToken);
+
+        bool alreadyIndexed = false;
+        if (pinned is null)
+        {
+            pinned = new PinnedContent
+            {
+                UserId = user.Id,
+                ContentId = content.Id,
+            };
+            dbContext.PinnedContents.Add(pinned);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        else
+        {
+            alreadyIndexed = pinned.IsIndexed;
+        }
+
+        // --- 5. Trigger indexing in background ---
+        if (!alreadyIndexed)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await contentPipeline.IndexContentAsync(content.Id, user.Id, CancellationToken.None);
+                    logger.LogInformation("Background indexing complete for content {ContentId} ({Title})", content.Id, content.Title);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Background indexing failed for content {ContentId}", content.Id);
+                }
+            });
+        }
+
+        return Result<PinMoodleModuleResponseDto>.Success(new PinMoodleModuleResponseDto(content.Id, alreadyIndexed));
+    }
+
+    private static ContentType MapContentType(string modType, string? fileUrl) => modType switch
+    {
+        "quiz" => ContentType.Quiz,
+        "assign" => ContentType.Assignment,
+        "url" => ContentType.Link,
+        "page" => ContentType.Html,
+        "resource" when fileUrl?.Contains(".pdf", StringComparison.OrdinalIgnoreCase) == true => ContentType.Pdf,
+        _ => ContentType.Document,
+    };
+}

--- a/src/Kursa.Frontend/src/app/core/services/pinned-content.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/pinned-content.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { MoodleCourse, MoodleModule } from './moodle.service';
+
+export interface PinMoodleModuleResponse {
+  contentId: string;
+  alreadyIndexed: boolean;
+}
 
 export interface PinnedContent {
   id: string;
@@ -34,5 +40,20 @@ export class PinnedContentService {
 
   toggleStar(contentId: string): Observable<{ isStarred: boolean }> {
     return this.http.post<{ isStarred: boolean }>(`${this.baseUrl}/${contentId}/star`, {});
+  }
+
+  pinMoodleModule(course: MoodleCourse, mod: MoodleModule): Observable<PinMoodleModuleResponse> {
+    const body = {
+      moodleCourseId: course.id,
+      courseName: course.fullName,
+      courseShortName: course.shortName,
+      moodleModuleId: mod.id,
+      moduleName: mod.name,
+      modType: mod.modName,
+      description: mod.description ?? null,
+      url: mod.url ?? null,
+      fileUrl: mod.contents?.find(c => c.fileUrl)?.fileUrl ?? null,
+    };
+    return this.http.post<PinMoodleModuleResponse>(`${this.baseUrl}/moodle`, body);
   }
 }

--- a/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
+++ b/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, input, signal, OnInit } from '@angular/core';
-import { MoodleCourseSection, MoodleModule, MoodleContent, MoodleService } from '../../core/services/moodle.service';
+import { MoodleCourse, MoodleCourseSection, MoodleModule, MoodleContent, MoodleService } from '../../core/services/moodle.service';
+import { PinnedContentService } from '../../core/services/pinned-content.service';
 import { DecimalPipe } from '@angular/common';
 
 @Component({
@@ -109,6 +110,31 @@ import { DecimalPipe } from '@angular/common';
                             Open
                           </a>
                         }
+                        <!-- Pin for AI button -->
+                        <button
+                          (click)="pinModule(mod)"
+                          [disabled]="pinningModuleId() === mod.id"
+                          [title]="pinnedModuleIds().has(mod.id) ? 'Pinned for AI' : 'Pin for AI'"
+                          [class]="pinnedModuleIds().has(mod.id)
+                            ? 'rounded-md px-2 py-1.5 text-xs transition-colors text-emerald-400 hover:bg-accent'
+                            : 'rounded-md px-2 py-1.5 text-xs transition-colors text-muted-foreground hover:text-foreground hover:bg-accent'"
+                          aria-label="Pin module for AI search"
+                        >
+                          @if (pinningModuleId() === mod.id) {
+                            <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+                            </svg>
+                          } @else if (pinnedModuleIds().has(mod.id)) {
+                            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                              <path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.4L12 17l-6.2 4.3 2.4-7.4L2 9.4h7.6z"/>
+                            </svg>
+                          } @else {
+                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-3.275a.562.562 0 0 0-.652 0L4.63 20.04a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557L.476 9.996a.563.563 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"/>
+                            </svg>
+                          }
+                        </button>
                       </div>
                     </li>
                   }
@@ -129,11 +155,15 @@ import { DecimalPipe } from '@angular/common';
 })
 export class CourseDetailComponent implements OnInit {
   private readonly moodleService = inject(MoodleService);
+  private readonly pinnedContentService = inject(PinnedContentService);
 
   readonly courseId = input.required<number>();
   readonly sections = signal<MoodleCourseSection[]>([]);
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
+  readonly course = signal<MoodleCourse | null>(null);
+  readonly pinnedModuleIds = signal<Set<number>>(new Set());
+  readonly pinningModuleId = signal<number | null>(null);
 
   ngOnInit(): void {
     this.moodleService.getCourseContent(this.courseId()).subscribe({
@@ -147,6 +177,29 @@ export class CourseDetailComponent implements OnInit {
           : (err.error?.detail ?? err.error?.title ?? err.message ?? 'Failed to load course content.');
         this.error.set(detail);
         this.loading.set(false);
+      },
+    });
+
+    this.moodleService.getEnrolledCourses().subscribe({
+      next: (courses) => {
+        const found = courses.find(c => c.id === this.courseId()) ?? null;
+        this.course.set(found);
+      },
+    });
+  }
+
+  pinModule(mod: MoodleModule): void {
+    const c = this.course();
+    if (!c || this.pinningModuleId() === mod.id) return;
+
+    this.pinningModuleId.set(mod.id);
+    this.pinnedContentService.pinMoodleModule(c, mod).subscribe({
+      next: () => {
+        this.pinnedModuleIds.update(ids => new Set([...ids, mod.id]));
+        this.pinningModuleId.set(null);
+      },
+      error: () => {
+        this.pinningModuleId.set(null);
       },
     });
   }


### PR DESCRIPTION
## Summary
- Adds `PinMoodleModuleCommand` that lazily creates the Course→Module→Content hierarchy when a user pins a Moodle module, then fires background RAG indexing via `IContentPipeline`
- Exposes `POST /api/pinned/moodle` endpoint
- Adds `pinMoodleModule()` to `PinnedContentService`
- Course detail now has a per-module pin button with pinned/pinning/unpinned states; loads enrolled course list to supply name/shortName for the command

## Test plan
- [ ] Navigate to a course, click the star/pin button on any module
- [ ] Verify the button spins then goes green (pinned state)
- [ ] Check DB: Course, Module, Content, and PinnedContent rows created
- [ ] Open the AI chat and ask about that module's content — verify RAG citations appear


Closes #105