### PR TITLE
feat(chat): agentic tool-calling RAG loop

### DIFF
--- a/src/Kursa.Application/Common/Interfaces/ILlmProvider.cs
+++ b/src/Kursa.Application/Common/Interfaces/ILlmProvider.cs
@@ -1,9 +1,15 @@
+using System.Text.Json;
+
 namespace Kursa.Application.Common.Interfaces;
 
 public interface ILlmProvider
 {
     Task<LlmChatResponse> ChatAsync(
         LlmChatRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<LlmChatResponse> ChatWithToolsAsync(
+        LlmChatRequestWithTools request,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<float>> GenerateEmbeddingAsync(
@@ -15,6 +21,8 @@ public interface ILlmProvider
         CancellationToken cancellationToken = default);
 }
 
+// ── Basic chat ──────────────────────────────────────────────────────────────
+
 public sealed record LlmChatRequest
 {
     public required string SystemPrompt { get; init; }
@@ -23,15 +31,63 @@ public sealed record LlmChatRequest
     public int? MaxTokens { get; init; }
 }
 
-public sealed record LlmMessage(string Role, string Content)
+// ── Tool-calling chat ───────────────────────────────────────────────────────
+
+public sealed record LlmChatRequestWithTools
 {
-    public static LlmMessage User(string content) => new("user", content);
-    public static LlmMessage Assistant(string content) => new("assistant", content);
+    public required string SystemPrompt { get; init; }
+    public required IReadOnlyList<LlmMessage> Messages { get; init; }
+    public required IReadOnlyList<LlmTool> Tools { get; init; }
+    public float Temperature { get; init; } = 0.3f;
+    public int? MaxTokens { get; init; }
 }
+
+/// <summary>A tool the agent can call, described by a JSON Schema for its input.</summary>
+public sealed record LlmTool(string Name, string Description, JsonElement InputSchema);
+
+/// <summary>A tool call requested by the LLM in a response.</summary>
+public sealed record LlmToolCall(string Id, string Name, string ArgumentsJson);
+
+// ── Messages (supports plain, tool-call request, and tool-result roles) ────
+
+public sealed record LlmMessage
+{
+    public string Role { get; init; } = string.Empty;
+    public string? Content { get; init; }
+
+    /// <summary>Set when the assistant is requesting tool calls (role = "assistant").</summary>
+    public IReadOnlyList<LlmToolCall>? ToolCalls { get; init; }
+    public bool HasToolCalls => ToolCalls?.Count > 0;
+
+    /// <summary>Set for role = "tool" to link the result back to the tool call.</summary>
+    public string? ToolCallId { get; init; }
+
+    // Convenience constructors kept for backwards compat
+    public LlmMessage() { }
+    public LlmMessage(string role, string content) { Role = role; Content = content; }
+
+    public static LlmMessage User(string content) => new() { Role = "user", Content = content };
+    public static LlmMessage Assistant(string content) => new() { Role = "assistant", Content = content };
+
+    public static LlmMessage AssistantWithToolCalls(IReadOnlyList<LlmToolCall> toolCalls) =>
+        new() { Role = "assistant", Content = null, ToolCalls = toolCalls };
+
+    public static LlmMessage ToolResult(string toolCallId, string content) =>
+        new() { Role = "tool", Content = content, ToolCallId = toolCallId };
+}
+
+// ── Response ────────────────────────────────────────────────────────────────
 
 public sealed record LlmChatResponse
 {
-    public required string Content { get; init; }
+    /// <summary>The final text answer. Null if the response only contains tool calls.</summary>
+    public string? Content { get; init; }
+
+    /// <summary>Tool calls requested by the LLM. Null or empty when the LLM returned a final answer.</summary>
+    public IReadOnlyList<LlmToolCall>? ToolCalls { get; init; }
+
+    public bool HasToolCalls => ToolCalls?.Count > 0;
+
     public int PromptTokens { get; init; }
     public int CompletionTokens { get; init; }
     public int TotalTokens => PromptTokens + CompletionTokens;

--- a/src/Kursa.Application/Features/Chat/Commands/SendChatMessage.cs
+++ b/src/Kursa.Application/Features/Chat/Commands/SendChatMessage.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentValidation;
 using Kursa.Application.Common.Interfaces;
 using Kursa.Application.Common.Models;
+using Kursa.Application.Features.Moodle.Models;
 using Kursa.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -24,21 +25,87 @@ public sealed class SendChatMessageHandler(
     IAppDbContext dbContext,
     ILlmProvider llmProvider,
     IVectorStore vectorStore,
+    IMoodleService moodleService,
     ILogger<SendChatMessageHandler> logger) : IRequestHandler<SendChatMessageCommand, Result<ChatResponseDto>>
 {
     private const string CollectionName = "content_chunks";
+    private const int MaxAgentIterations = 5;
 
     private const string SystemPrompt =
         """
-        You are Kursa, an AI study assistant. Answer the user's question based on the provided context from their course materials.
+        You are Kursa, an AI study assistant integrated with Moodle and indexed course materials.
 
-        Rules:
-        - Use ONLY the provided context to answer. If the context doesn't contain relevant information, say so.
-        - When referencing information from the context, cite the source using [Source N] format where N corresponds to the source number.
-        - Be concise but thorough. Use bullet points and structure where helpful.
+        You have the following tools available:
+        - search_course_materials: Searches the user's pinned and indexed course documents using semantic search. Use this when the user asks about specific course content, topics, learning objectives, or study material.
+        - list_enrolled_courses: Lists all Moodle courses the user is enrolled in. Use this when the user asks what courses they have, wants to browse their courses, or needs a course ID.
+        - get_course_content: Gets the full list of modules and resources in a specific Moodle course. Use this when the user asks about the structure or contents of a course.
+
+        Decision rules:
+        - For greetings, general knowledge, or questions that don't need course materials → answer directly without calling any tools.
+        - For questions about course content, topics, or specific material → call search_course_materials first. If results are poor (low relevance), try with a more specific query.
+        - For questions about "what courses do I have" or browsing courses → call list_enrolled_courses.
+        - For questions about what's in a specific course → call get_course_content.
+        - You may call tools multiple times with refined queries if the first result doesn't answer the question well.
+
+        When answering based on tool results:
+        - Cite sources using [Source N] format when referencing specific content.
         - Write in the same language as the user's question.
-        - If the user asks something unrelated to study materials, politely redirect them.
+        - Be concise but thorough.
         """;
+
+    // ── Tool schemas ───────────────────────────────────────────────────────
+
+    private static readonly IReadOnlyList<LlmTool> AgentTools =
+    [
+        new LlmTool(
+            "search_course_materials",
+            "Semantically searches the user's pinned and indexed course documents. Returns the most relevant chunks of text with source titles and relevance scores.",
+            JsonDocument.Parse("""
+                {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "string",
+                      "description": "The search query optimized for semantic retrieval, e.g. 'learning objectives for marketing' or 'Break-even point formula'"
+                    },
+                    "limit": {
+                      "type": "integer",
+                      "description": "Maximum number of results to return (1-10). Default 5.",
+                      "default": 5
+                    }
+                  },
+                  "required": ["query"]
+                }
+                """).RootElement),
+
+        new LlmTool(
+            "list_enrolled_courses",
+            "Returns a list of all Moodle courses the user is enrolled in, including course IDs, names, and progress.",
+            JsonDocument.Parse("""
+                {
+                  "type": "object",
+                  "properties": {}
+                }
+                """).RootElement),
+
+        new LlmTool(
+            "get_course_content",
+            "Returns the sections and modules of a specific Moodle course by its numeric ID. Includes module names, types, and descriptions.",
+            JsonDocument.Parse("""
+                {
+                  "type": "object",
+                  "properties": {
+                    "courseId": {
+                      "type": "integer",
+                      "description": "The numeric Moodle course ID (obtain from list_enrolled_courses if unknown)"
+                    }
+                  },
+                  "required": ["courseId"]
+                }
+                """).RootElement),
+    ];
+
+    // ── Handler ────────────────────────────────────────────────────────────
 
     public async Task<Result<ChatResponseDto>> Handle(SendChatMessageCommand request, CancellationToken cancellationToken)
     {
@@ -70,11 +137,7 @@ public sealed class SendChatMessageHandler(
                 ? string.Concat(request.Message.AsSpan(0, 77), "...")
                 : request.Message;
 
-            thread = new ChatThread
-            {
-                UserId = user.Id,
-                Title = title,
-            };
+            thread = new ChatThread { UserId = user.Id, Title = title };
             dbContext.ChatThreads.Add(thread);
         }
 
@@ -87,91 +150,185 @@ public sealed class SendChatMessageHandler(
         };
         dbContext.ChatMessages.Add(userMessage);
 
-        // RAG: embed the question and search for relevant chunks
-        IReadOnlyList<float> questionEmbedding = await llmProvider.GenerateEmbeddingAsync(request.Message, cancellationToken);
-
-        IReadOnlyList<VectorSearchResult> searchResults = await vectorStore.SearchAsync(
-            CollectionName,
-            questionEmbedding,
-            limit: 5,
-            filterByUserId: user.Id,
-            cancellationToken: cancellationToken);
-
-        // Build context with sources
-        var citations = new List<CitationDto>();
-        string contextBlock = string.Empty;
-
-        if (searchResults.Count > 0)
+        // Build message history for the agent
+        var messages = new List<LlmMessage>();
+        foreach (ChatMessage msg in thread.Messages.TakeLast(10))
         {
-            var contextParts = new List<string>();
-            for (int i = 0; i < searchResults.Count; i++)
-            {
-                VectorSearchResult result = searchResults[i];
-                contextParts.Add($"[Source {i + 1}] (from: {result.ContentTitle})\n{result.ChunkText}");
-                citations.Add(new CitationDto(
-                    result.ContentId,
-                    result.ContentTitle ?? "Unknown",
-                    result.ChunkText,
-                    result.Score,
-                    result.SourceUrl));
-            }
-            contextBlock = "## Relevant Context\n\n" + string.Join("\n\n---\n\n", contextParts);
+            messages.Add(new LlmMessage(msg.Role, msg.Content));
         }
+        messages.Add(LlmMessage.User(request.Message));
 
-        // Build messages for LLM
-        var llmMessages = new List<LlmMessage>();
+        // Run the agentic loop
+        var allCitations = new List<CitationDto>();
+        string? finalAnswer = null;
 
-        // Include recent conversation history (last 10 messages)
-        IEnumerable<ChatMessage> recentMessages = thread.Messages.TakeLast(10);
-        foreach (ChatMessage msg in recentMessages)
+        for (int iteration = 0; iteration < MaxAgentIterations; iteration++)
         {
-            llmMessages.Add(new LlmMessage(msg.Role, msg.Content));
-        }
-
-        // Add current user message with context
-        string userPrompt = string.IsNullOrEmpty(contextBlock)
-            ? request.Message
-            : $"{contextBlock}\n\n## User Question\n{request.Message}";
-        llmMessages.Add(LlmMessage.User(userPrompt));
-
-        try
-        {
-            LlmChatResponse llmResponse = await llmProvider.ChatAsync(new LlmChatRequest
+            LlmChatResponse response = await llmProvider.ChatWithToolsAsync(new LlmChatRequestWithTools
             {
                 SystemPrompt = SystemPrompt,
-                Messages = llmMessages,
-                Temperature = 0.4f,
+                Messages = messages,
+                Tools = AgentTools,
+                Temperature = 0.3f,
                 MaxTokens = 2048,
             }, cancellationToken);
 
-            // Save assistant message
-            var assistantMessage = new ChatMessage
+            // Final answer — no more tool calls
+            if (!response.HasToolCalls)
             {
-                ThreadId = thread.Id,
-                Role = "assistant",
-                Content = llmResponse.Content,
-                Citations = citations.Count > 0 ? JsonSerializer.Serialize(citations) : null,
-                TokensUsed = llmResponse.TotalTokens,
+                finalAnswer = response.Content ?? string.Empty;
+                break;
+            }
+
+            // Execute tool calls, add results to message history
+            messages.Add(LlmMessage.AssistantWithToolCalls(response.ToolCalls!));
+
+            foreach (LlmToolCall toolCall in response.ToolCalls!)
+            {
+                logger.LogInformation("Agent calling tool {Tool} (iteration {Iteration}): {Args}",
+                    toolCall.Name, iteration + 1, toolCall.ArgumentsJson);
+
+                (string toolResultContent, List<CitationDto> citations) =
+                    await ExecuteToolAsync(toolCall, user, cancellationToken);
+
+                allCitations.AddRange(citations);
+                messages.Add(LlmMessage.ToolResult(toolCall.Id, toolResultContent));
+            }
+        }
+
+        // Fallback if max iterations hit without a final answer
+        finalAnswer ??= "I wasn't able to find a complete answer. Please try rephrasing your question.";
+
+        // Save assistant message
+        var assistantMessage = new ChatMessage
+        {
+            ThreadId = thread.Id,
+            Role = "assistant",
+            Content = finalAnswer,
+            Citations = allCitations.Count > 0 ? JsonSerializer.Serialize(allCitations) : null,
+        };
+        dbContext.ChatMessages.Add(assistantMessage);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var responseDto = new ChatResponseDto(
+            new ChatMessageDto(
+                assistantMessage.Id,
+                assistantMessage.Role,
+                assistantMessage.Content,
+                assistantMessage.Citations,
+                assistantMessage.TokensUsed,
+                assistantMessage.CreatedAt),
+            allCitations);
+
+        return Result<ChatResponseDto>.Success(responseDto);
+    }
+
+    // ── Tool execution ─────────────────────────────────────────────────────
+
+    private async Task<(string Content, List<CitationDto> Citations)> ExecuteToolAsync(
+        LlmToolCall toolCall,
+        Kursa.Domain.Entities.User user,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return toolCall.Name switch
+            {
+                "search_course_materials" => await SearchCourseMaterialsAsync(toolCall.ArgumentsJson, user.Id, cancellationToken),
+                "list_enrolled_courses" => await ListEnrolledCoursesAsync(user, cancellationToken),
+                "get_course_content" => await GetCourseContentAsync(toolCall.ArgumentsJson, user, cancellationToken),
+                _ => ($"Unknown tool: {toolCall.Name}", [])
             };
-            dbContext.ChatMessages.Add(assistantMessage);
-            await dbContext.SaveChangesAsync(cancellationToken);
-
-            var responseDto = new ChatResponseDto(
-                new ChatMessageDto(
-                    assistantMessage.Id,
-                    assistantMessage.Role,
-                    assistantMessage.Content,
-                    assistantMessage.Citations,
-                    assistantMessage.TokensUsed,
-                    assistantMessage.CreatedAt),
-                citations);
-
-            return Result<ChatResponseDto>.Success(responseDto);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get LLM response for thread {ThreadId}", thread.Id);
-            return Result<ChatResponseDto>.Failure("Failed to generate response. Please try again.");
+            logger.LogError(ex, "Tool {Tool} failed", toolCall.Name);
+            return ($"Tool {toolCall.Name} failed: {ex.Message}", []);
         }
+    }
+
+    private async Task<(string Content, List<CitationDto> Citations)> SearchCourseMaterialsAsync(
+        string argsJson, Guid userId, CancellationToken cancellationToken)
+    {
+        using JsonDocument args = JsonDocument.Parse(argsJson);
+        string query = args.RootElement.GetProperty("query").GetString() ?? string.Empty;
+        int limit = args.RootElement.TryGetProperty("limit", out JsonElement limitEl)
+            ? Math.Clamp(limitEl.GetInt32(), 1, 10)
+            : 5;
+
+        IReadOnlyList<float> embedding = await llmProvider.GenerateEmbeddingAsync(query, cancellationToken);
+        IReadOnlyList<VectorSearchResult> results = await vectorStore.SearchAsync(
+            CollectionName, embedding, limit: limit, filterByUserId: userId, cancellationToken: cancellationToken);
+
+        if (results.Count == 0)
+            return ("No relevant course materials found for this query.", []);
+
+        var citations = new List<CitationDto>();
+        var parts = new List<string>();
+        for (int i = 0; i < results.Count; i++)
+        {
+            VectorSearchResult r = results[i];
+            parts.Add($"[Source {i + 1}] {r.ContentTitle} (relevance: {r.Score:F2})\n{r.ChunkText}");
+            citations.Add(new CitationDto(r.ContentId, r.ContentTitle ?? "Unknown", r.ChunkText, r.Score, r.SourceUrl));
+        }
+
+        return (string.Join("\n\n---\n\n", parts), citations);
+    }
+
+    private async Task<(string Content, List<CitationDto> Citations)> ListEnrolledCoursesAsync(
+        Kursa.Domain.Entities.User user, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(user.MoodleToken))
+            return ("User has not linked their Moodle account yet.", []);
+
+        IReadOnlyList<MoodleCourseDto> courses = await moodleService.GetEnrolledCoursesAsync(
+            user.MoodleToken, cancellationToken);
+
+        if (courses.Count == 0)
+            return ("No enrolled courses found.", []);
+
+        var lines = courses.Select(c =>
+            $"- [{c.Id}] {c.FullName} ({c.ShortName})" +
+            (c.Progress.HasValue ? $" — {c.Progress:F0}% complete" : string.Empty));
+
+        return ($"Enrolled courses ({courses.Count} total):\n{string.Join('\n', lines)}", []);
+    }
+
+    private async Task<(string Content, List<CitationDto> Citations)> GetCourseContentAsync(
+        string argsJson, Kursa.Domain.Entities.User user, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(user.MoodleToken))
+            return ("User has not linked their Moodle account yet.", []);
+
+        using JsonDocument args = JsonDocument.Parse(argsJson);
+        int courseId = args.RootElement.GetProperty("courseId").GetInt32();
+
+        IReadOnlyList<MoodleCourseSectionDto> sections = await moodleService.GetCourseContentAsync(
+            user.MoodleToken, courseId, cancellationToken);
+
+        if (sections.Count == 0)
+            return ("No content found for this course.", []);
+
+        var lines = new List<string>();
+        foreach (MoodleCourseSectionDto section in sections.Where(s => s.Visible != 0 && s.Modules.Count > 0))
+        {
+            lines.Add($"## {section.Name}");
+            foreach (MoodleModuleDto mod in section.Modules.Where(m => m.Visible != 0))
+            {
+                string fileInfo = mod.Contents?.Count > 0 ? $" ({mod.Contents.Count} file(s))" : string.Empty;
+                lines.Add($"  - [{mod.ModName}] {mod.Name}{fileInfo}");
+                if (!string.IsNullOrWhiteSpace(mod.Description))
+                {
+                    // Strip HTML tags for a readable plain-text summary
+                    string desc = System.Text.RegularExpressions.Regex.Replace(mod.Description, "<[^>]+>", " ")
+                        .Replace("&nbsp;", " ").Trim();
+                    if (desc.Length > 200) desc = string.Concat(desc.AsSpan(0, 197), "...");
+                    if (!string.IsNullOrWhiteSpace(desc))
+                        lines.Add($"    {desc}");
+                }
+            }
+        }
+
+        return (string.Join('\n', lines), []);
     }
 }

--- a/src/Kursa.Infrastructure/Services/OllamaLlmProvider.cs
+++ b/src/Kursa.Infrastructure/Services/OllamaLlmProvider.cs
@@ -75,6 +75,11 @@ public sealed class OllamaLlmProvider : ILlmProvider
         };
     }
 
+    public Task<LlmChatResponse> ChatWithToolsAsync(
+        LlmChatRequestWithTools request,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Ollama provider does not support tool calling. Use OpenRouter provider.");
+
     public async Task<IReadOnlyList<float>> GenerateEmbeddingAsync(
         string text,
         CancellationToken cancellationToken = default)

--- a/src/Kursa.Infrastructure/Services/OpenRouterLlmProvider.cs
+++ b/src/Kursa.Infrastructure/Services/OpenRouterLlmProvider.cs
@@ -1,4 +1,5 @@
 using System.ClientModel;
+using System.Text.Json;
 using Kursa.Application.Common.Interfaces;
 using Kursa.Infrastructure.Options;
 using Microsoft.Extensions.Logging;
@@ -47,30 +48,11 @@ public sealed class OpenRouterLlmProvider : ILlmProvider
         LlmChatRequest request,
         CancellationToken cancellationToken = default)
     {
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(request.SystemPrompt)
-        };
+        List<ChatMessage> messages = BuildMessages(request.SystemPrompt, request.Messages);
 
-        foreach (LlmMessage msg in request.Messages)
-        {
-            messages.Add(msg.Role switch
-            {
-                "user" => new UserChatMessage(msg.Content),
-                "assistant" => new AssistantChatMessage(msg.Content),
-                _ => new UserChatMessage(msg.Content)
-            });
-        }
-
-        var chatOptions = new ChatCompletionOptions
-        {
-            Temperature = request.Temperature,
-        };
-
+        var chatOptions = new ChatCompletionOptions { Temperature = request.Temperature };
         if (request.MaxTokens.HasValue)
-        {
             chatOptions.MaxOutputTokenCount = request.MaxTokens.Value;
-        }
 
         _logger.LogDebug("Sending OpenRouter chat request with {MessageCount} messages", messages.Count);
 
@@ -84,16 +66,63 @@ public sealed class OpenRouterLlmProvider : ILlmProvider
         };
     }
 
+    public async Task<LlmChatResponse> ChatWithToolsAsync(
+        LlmChatRequestWithTools request,
+        CancellationToken cancellationToken = default)
+    {
+        List<ChatMessage> messages = BuildMessages(request.SystemPrompt, request.Messages);
+
+        var chatOptions = new ChatCompletionOptions { Temperature = request.Temperature };
+        if (request.MaxTokens.HasValue)
+            chatOptions.MaxOutputTokenCount = request.MaxTokens.Value;
+
+        // Map LlmTool → OpenAI ChatTool
+        foreach (LlmTool tool in request.Tools)
+        {
+            chatOptions.Tools.Add(ChatTool.CreateFunctionTool(
+                functionName: tool.Name,
+                functionDescription: tool.Description,
+                functionParameters: BinaryData.FromString(tool.InputSchema.GetRawText())));
+        }
+
+        _logger.LogDebug("Sending OpenRouter tool-calling request with {MessageCount} messages, {ToolCount} tools",
+            messages.Count, request.Tools.Count);
+
+        ChatCompletion completion = await _chatClient.CompleteChatAsync(messages, chatOptions, cancellationToken);
+
+        // Tool call response
+        if (completion.FinishReason == ChatFinishReason.ToolCalls)
+        {
+            var toolCalls = completion.ToolCalls
+                .Select(tc => new LlmToolCall(tc.Id, tc.FunctionName, tc.FunctionArguments.ToString()))
+                .ToList();
+
+            return new LlmChatResponse
+            {
+                Content = null,
+                ToolCalls = toolCalls,
+                PromptTokens = completion.Usage?.InputTokenCount ?? 0,
+                CompletionTokens = completion.Usage?.OutputTokenCount ?? 0,
+            };
+        }
+
+        // Final text answer
+        return new LlmChatResponse
+        {
+            Content = completion.Content.Count > 0 ? completion.Content[0].Text : string.Empty,
+            ToolCalls = null,
+            PromptTokens = completion.Usage?.InputTokenCount ?? 0,
+            CompletionTokens = completion.Usage?.OutputTokenCount ?? 0,
+        };
+    }
+
     public async Task<IReadOnlyList<float>> GenerateEmbeddingAsync(
         string text,
         CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Generating embedding via Ollama for text of length {Length}", text.Length);
-
         OpenAIEmbedding embedding = await _embeddingClient.GenerateEmbeddingAsync(text, cancellationToken: cancellationToken);
-        ReadOnlyMemory<float> vector = embedding.ToFloats();
-
-        return vector.ToArray();
+        return embedding.ToFloats().ToArray();
     }
 
     public async Task<IReadOnlyList<IReadOnlyList<float>>> GenerateEmbeddingsAsync(
@@ -101,11 +130,38 @@ public sealed class OpenRouterLlmProvider : ILlmProvider
         CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Generating embeddings via Ollama for {Count} texts", texts.Count);
-
         OpenAIEmbeddingCollection embeddings = await _embeddingClient.GenerateEmbeddingsAsync(texts, cancellationToken: cancellationToken);
+        return embeddings.Select(e => (IReadOnlyList<float>)e.ToFloats().ToArray()).ToList();
+    }
 
-        return embeddings
-            .Select(e => (IReadOnlyList<float>)e.ToFloats().ToArray())
-            .ToList();
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static List<ChatMessage> BuildMessages(string systemPrompt, IReadOnlyList<LlmMessage> messages)
+    {
+        var result = new List<ChatMessage> { new SystemChatMessage(systemPrompt) };
+
+        foreach (LlmMessage msg in messages)
+        {
+            ChatMessage chatMessage = msg.Role switch
+            {
+                "user" => new UserChatMessage(msg.Content ?? string.Empty),
+
+                "assistant" when msg.HasToolCalls =>
+                    new AssistantChatMessage(
+                        msg.ToolCalls!.Select(tc =>
+                            ChatToolCall.CreateFunctionToolCall(tc.Id, tc.Name,
+                                BinaryData.FromString(tc.ArgumentsJson)))),
+
+                "assistant" => new AssistantChatMessage(msg.Content ?? string.Empty),
+
+                "tool" => new ToolChatMessage(msg.ToolCallId!, msg.Content ?? string.Empty),
+
+                _ => new UserChatMessage(msg.Content ?? string.Empty)
+            };
+
+            result.Add(chatMessage);
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
## Summary
- Replaces hardcoded single-shot RAG with a ReAct-style agentic loop (up to 5 iterations)
- LLM decides when/whether to call tools — skips search for greetings and general questions
- Three tools: `search_course_materials` (Qdrant), `list_enrolled_courses` (Moodle), `get_course_content` (Moodle)
- Extends `ILlmProvider` with `ChatWithToolsAsync` for OpenAI-compatible function calling
- `OpenRouterLlmProvider` implements function calling; `OllamaLlmProvider` stubs with `NotSupportedException`

## Test plan
- [ ] Ask "hi" → agent answers directly without calling any tools
- [ ] Ask about course content → agent calls `search_course_materials` and cites sources
- [ ] Ask "what courses do I have" → agent calls `list_enrolled_courses`
- [ ] Ask about a specific course structure → agent calls `get_course_content`
- [ ] Build passes with 0 errors: `dotnet build`

Closes #110