### PR TITLE
feat(ai-panel): context-aware panel + markdown rendering

### DIFF
--- a/src/Kursa.Frontend/src/app/core/services/ai-context.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/ai-context.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, signal, computed } from '@angular/core';
 
 export interface ViewContext {
-  type: 'course' | 'content' | 'module' | 'none';
+  type: 'course' | 'content' | 'module' | 'recording' | 'flashcards' | 'quizzes' | 'none';
   id?: string;
   title?: string;
   description?: string;

--- a/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
+++ b/src/Kursa.Frontend/src/app/features/courses/course-detail.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, Component, inject, input, signal, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, signal, OnInit, OnDestroy } from '@angular/core';
 import { MoodleCourse, MoodleCourseSection, MoodleModule, MoodleContent, MoodleService } from '../../core/services/moodle.service';
 import { PinnedContentService } from '../../core/services/pinned-content.service';
+import { AiContextService } from '../../core/services/ai-context.service';
 import { DecimalPipe } from '@angular/common';
 
 @Component({
@@ -153,9 +154,10 @@ import { DecimalPipe } from '@angular/common';
     </div>
   `,
 })
-export class CourseDetailComponent implements OnInit {
+export class CourseDetailComponent implements OnInit, OnDestroy {
   private readonly moodleService = inject(MoodleService);
   private readonly pinnedContentService = inject(PinnedContentService);
+  private readonly aiContext = inject(AiContextService);
 
   readonly courseId = input.required<number>();
   readonly sections = signal<MoodleCourseSection[]>([]);
@@ -185,8 +187,20 @@ export class CourseDetailComponent implements OnInit {
         const id = +this.courseId();
         const found = courses.find(c => c.id === id) ?? null;
         this.course.set(found);
+        if (found) {
+          this.aiContext.setContext({
+            type: 'course',
+            id: String(found.id),
+            title: found.fullName,
+            description: `Moodle course — ${found.shortName}`,
+          });
+        }
       },
     });
+  }
+
+  ngOnDestroy(): void {
+    this.aiContext.clearContext();
   }
 
   pinModule(mod: MoodleModule): void {

--- a/src/Kursa.Frontend/src/app/layout/ai-panel.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/ai-panel.component.ts
@@ -1,6 +1,8 @@
-import { ChangeDetectionStrategy, Component, inject, signal, ElementRef, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal, ElementRef, viewChild, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AiContextService } from '../core/services/ai-context.service';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { marked } from 'marked';
+import { AiContextService, ViewContext } from '../core/services/ai-context.service';
 import { ChatService, ChatMessage, Citation, ChatResponse } from '../core/services/chat.service';
 
 @Component({
@@ -36,9 +38,19 @@ import { ChatService, ChatMessage, Citation, ChatResponse } from '../core/servic
 
       <!-- Context banner -->
       @if (contextService.hasContext()) {
-        <div class="border-b border-border bg-accent/30 px-4 py-2">
-          <p class="text-xs text-muted-foreground">Context</p>
-          <p class="text-sm font-medium text-foreground line-clamp-1">{{ contextService.currentContext().title }}</p>
+        <div class="border-b border-border bg-primary/5 px-4 py-2.5 flex items-start gap-2.5">
+          <div class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary/15 text-primary" aria-hidden="true">
+            <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" [attr.d]="contextIconPath()" />
+            </svg>
+          </div>
+          <div class="min-w-0 flex-1">
+            <p class="text-xs font-medium text-primary">{{ contextLabel() }}</p>
+            <p class="text-sm font-semibold text-foreground leading-tight line-clamp-2">{{ contextService.currentContext().title }}</p>
+            @if (contextService.currentContext().description) {
+              <p class="text-xs text-muted-foreground mt-0.5">{{ contextService.currentContext().description }}</p>
+            }
+          </div>
         </div>
       }
 
@@ -61,10 +73,14 @@ import { ChatService, ChatMessage, Citation, ChatResponse } from '../core/servic
         @for (msg of messages(); track msg.id) {
           <div [class]="msg.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
             <div
-              class="max-w-[85%] rounded-lg px-3 py-2"
+              class="max-w-[85%] rounded-lg px-3 py-2 text-sm"
               [class]="msg.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'"
             >
-              <p class="whitespace-pre-wrap text-sm">{{ msg.content }}</p>
+              @if (msg.role === 'assistant') {
+                <div class="markdown-body prose prose-sm prose-invert max-w-none" [innerHTML]="renderMarkdown(msg.content)"></div>
+              } @else {
+                <p class="whitespace-pre-wrap">{{ msg.content }}</p>
+              }
             </div>
           </div>
         }
@@ -102,7 +118,7 @@ import { ChatService, ChatMessage, Citation, ChatResponse } from '../core/servic
             type="text"
             [(ngModel)]="inputMessage"
             name="message"
-            placeholder="Ask about this..."
+            [placeholder]="inputPlaceholder()"
             [disabled]="loading()"
             class="flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
           />
@@ -124,11 +140,49 @@ import { ChatService, ChatMessage, Citation, ChatResponse } from '../core/servic
 export class AiPanelComponent {
   readonly contextService = inject(AiContextService);
   private readonly chatService = inject(ChatService);
+  private readonly sanitizer = inject(DomSanitizer);
   private readonly messagesContainer = viewChild<ElementRef<HTMLDivElement>>('messagesContainer');
 
   readonly messages = signal<ChatMessage[]>([]);
   readonly sources = signal<Citation[]>([]);
   readonly loading = signal(false);
+
+  readonly contextLabel = computed(() => {
+    const type = this.contextService.currentContext().type;
+    const labels: Partial<Record<ViewContext['type'], string>> = {
+      course: 'Viewing course',
+      module: 'Viewing module',
+      content: 'Viewing content',
+      recording: 'Viewing recording',
+      flashcards: 'Flashcards',
+      quizzes: 'Quizzes',
+    };
+    return labels[type] ?? 'Context';
+  });
+
+  readonly contextIconPath = computed(() => {
+    const type = this.contextService.currentContext().type;
+    switch (type) {
+      case 'course':
+        return 'M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25';
+      case 'recording':
+        return 'M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z';
+      case 'flashcards':
+        return 'M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3';
+      case 'quizzes':
+        return 'M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z';
+      default:
+        return 'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z';
+    }
+  });
+
+  readonly inputPlaceholder = computed(() => {
+    const ctx = this.contextService.currentContext();
+    if (ctx.type === 'course' && ctx.title) {
+      return `Ask about ${ctx.title}…`;
+    }
+    return 'Ask about your course materials…';
+  });
 
   inputMessage = '';
   private threadId: string | undefined;
@@ -180,6 +234,10 @@ export class AiPanelComponent {
         this.messages.update((msgs) => [...msgs, errorMsg]);
       },
     });
+  }
+
+  renderMarkdown(content: string): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(marked.parse(content) as string);
   }
 
   private scrollToBottom(): void {


### PR DESCRIPTION
## Summary
- When navigating to a course page (`/courses/:id`), the AI side panel now auto-detects the current course and shows a context banner: **"Viewing course — Betriebswirtschaftslehre / Moodle course — BM_BWL"**
- The input placeholder adapts: `Ask about Betriebswirtschaftslehre…`
- Every message sent from the panel includes `[Context: course — <name>]` so the AI answers in scope
- Assistant responses now render full **markdown** (headings, bold, lists) via `marked` + `DomSanitizer`

## Test plan
- [x] Navigate to any course → AI panel context banner appears with course name and short name
- [x] Ask a question → response uses markdown formatting (headers, bullet points, bold)
- [x] Navigate away → context clears, banner disappears
- [x] Build passes without errors (`ng build`)
- [x] Visually verified with Playwright

Closes #114