### PR TITLE
fix(onboarding): enforce onboarding flow and ensure user exists before Moodle link

### DIFF
--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { ShellComponent } from './layout/shell.component';
 import { authGuard } from './core/guards/auth.guard';
+import { onboardingGuard } from './core/guards/onboarding.guard';
 
 export const routes: Routes = [
   {
@@ -22,7 +23,7 @@ export const routes: Routes = [
   {
     path: '',
     component: ShellComponent,
-    canActivate: [authGuard],
+    canActivate: [authGuard, onboardingGuard],
     children: [
       {
         path: '',

--- a/src/Kursa.Frontend/src/app/core/guards/onboarding.guard.ts
+++ b/src/Kursa.Frontend/src/app/core/guards/onboarding.guard.ts
@@ -1,0 +1,19 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { catchError, map, of } from 'rxjs';
+
+export const onboardingGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  const profile = authService.profile();
+  if (profile) {
+    return profile.onboardingCompleted ? true : router.createUrlTree(['/onboarding']);
+  }
+
+  return authService.getCurrentUser().pipe(
+    map((user) => (user.onboardingCompleted ? true : router.createUrlTree(['/onboarding']))),
+    catchError(() => of(true)),
+  );
+};

--- a/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
+++ b/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from '../../core/services/auth.service';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-callback',
@@ -40,7 +41,12 @@ export class CallbackComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     const success = await this.authService.handleCallback();
     if (success) {
-      await this.router.navigate(['/dashboard']);
+      try {
+        const user = await firstValueFrom(this.authService.getCurrentUser());
+        await this.router.navigate([user.onboardingCompleted ? '/dashboard' : '/onboarding']);
+      } catch {
+        await this.router.navigate(['/dashboard']);
+      }
     } else {
       this.error.set(
         'Sign-in failed. Make sure the Pocket ID client has redirect URL ' +

--- a/src/Kursa.Frontend/src/app/features/onboarding/onboarding.component.ts
+++ b/src/Kursa.Frontend/src/app/features/onboarding/onboarding.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { HlmButton } from '@spartan-ng/helm/button';
@@ -149,7 +149,7 @@ import { MoodleService } from '../../core/services/moodle.service';
     </div>
   `,
 })
-export class OnboardingComponent {
+export class OnboardingComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
   private readonly moodleService = inject(MoodleService);
@@ -162,6 +162,11 @@ export class OnboardingComponent {
   moodleUsername = '';
   moodlePassword = '';
   selectedTheme = 'dark';
+
+  ngOnInit(): void {
+    // Ensure the user record exists in the DB before any actions (e.g. Moodle linking)
+    this.authService.getCurrentUser().subscribe();
+  }
 
   next(): void {
     if (this.currentStep() === 1 && this.moodleUsername && this.moodlePassword) {


### PR DESCRIPTION
## Summary
- Add `onboardingGuard` that checks `onboardingCompleted` and redirects to `/onboarding` if false
- Call `/api/auth/me` on `OnboardingComponent` init to ensure user record exists in DB before Moodle linking
- Update `CallbackComponent` to redirect new users to `/onboarding` instead of `/dashboard`
- Remove debug logging from `MoodleService`

Closes #126

## Test plan
- [ ] Fresh DB: login → auto-redirected to `/onboarding`
- [ ] Complete onboarding → redirected to `/dashboard`, subsequent visits skip onboarding
- [ ] Moodle link step works (user exists in DB before `/api/moodle/link` is called)
- [ ] Manually navigating to `/dashboard` redirects back to `/onboarding` if not completed