### PR TITLE
fix(auth): overhaul auth flow for Pocket ID OIDC compatibility

### DIFF
--- a/src/Kursa.API/Controllers/AuthController.cs
+++ b/src/Kursa.API/Controllers/AuthController.cs
@@ -1,6 +1,10 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
 using Kursa.Application.Common.Interfaces;
+using Kursa.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace Kursa.API.Controllers;
 
@@ -9,21 +13,27 @@ namespace Kursa.API.Controllers;
 [Authorize]
 public class AuthController(
     ICurrentUserService currentUserService,
-    IUserSyncService userSyncService) : ControllerBase
+    IUserSyncService userSyncService,
+    IAppDbContext dbContext,
+    IHttpClientFactory httpClientFactory,
+    IConfiguration configuration) : ControllerBase
 {
+    /// <summary>
+    /// Returns the current user profile. Returns 404 if the user hasn't completed registration yet.
+    /// </summary>
     [HttpGet("me")]
     public async Task<IActionResult> GetCurrentUserAsync(CancellationToken cancellationToken)
     {
-        if (currentUserService.ExternalId is null || currentUserService.Email is null)
-        {
+        string? externalId = currentUserService.ExternalId;
+        if (externalId is null)
             return Unauthorized();
-        }
 
-        var user = await userSyncService.SyncUserAsync(
-            currentUserService.ExternalId,
-            currentUserService.Email,
-            currentUserService.DisplayName ?? currentUserService.Email,
-            cancellationToken);
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalId == externalId, cancellationToken);
+
+        if (user is null)
+            return NotFound(new { message = "User not registered." });
 
         return Ok(new
         {
@@ -36,4 +46,70 @@ public class AuthController(
             HasMoodleToken = user.MoodleToken is not null
         });
     }
+
+    /// <summary>
+    /// Creates the user record in the DB after onboarding is complete.
+    /// Fetches profile info from the OIDC userinfo endpoint if not available in the token.
+    /// </summary>
+    [HttpPost("register")]
+    public async Task<IActionResult> RegisterAsync(CancellationToken cancellationToken)
+    {
+        string? externalId = currentUserService.ExternalId;
+        if (externalId is null)
+            return Unauthorized();
+
+        // Get email/name from token claims, fall back to userinfo endpoint
+        string? email = currentUserService.Email;
+        string? displayName = currentUserService.DisplayName;
+
+        if (string.IsNullOrEmpty(email))
+        {
+            var userInfo = await FetchUserInfoAsync(cancellationToken);
+            email = userInfo?.Email ?? $"{externalId}@unknown";
+            displayName ??= userInfo?.Name ?? email;
+        }
+
+        var user = await userSyncService.SyncUserAsync(
+            externalId, email, displayName ?? email, cancellationToken);
+
+        user.OnboardingCompleted = true;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(new
+        {
+            user.Id,
+            user.Email,
+            user.DisplayName,
+            user.Role,
+            user.OnboardingCompleted,
+            user.MoodleUrl,
+            HasMoodleToken = user.MoodleToken is not null
+        });
+    }
+
+    private async Task<OidcUserInfo?> FetchUserInfoAsync(CancellationToken cancellationToken)
+    {
+        string? authority = configuration["Oidc:Authority"];
+        if (string.IsNullOrEmpty(authority)) return null;
+
+        // Extract the Bearer token from the current request
+        string? accessToken = HttpContext.Request.Headers.Authorization
+            .ToString().Replace("Bearer ", "", StringComparison.OrdinalIgnoreCase).Trim();
+        if (string.IsNullOrEmpty(accessToken)) return null;
+
+        var client = httpClientFactory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{authority.TrimEnd('/')}/api/oidc/userinfo");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        var response = await client.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode) return null;
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonSerializer.Deserialize<OidcUserInfo>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+    }
+
+    private sealed record OidcUserInfo(string? Sub, string? Email, string? Name);
 }

--- a/src/Kursa.API/Controllers/MoodleController.cs
+++ b/src/Kursa.API/Controllers/MoodleController.cs
@@ -21,6 +21,21 @@ public class MoodleController(ISender sender) : ControllerBase
             : BadRequest(result.Error);
     }
 
+    /// <summary>
+    /// Validates Moodle credentials without storing them. Used during onboarding before user is created.
+    /// </summary>
+    [HttpPost("validate")]
+    public async Task<IActionResult> ValidateCredentialsAsync(
+        ValidateMoodleCredentialsCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Ok()
+            : BadRequest(result.Error);
+    }
+
     [HttpPost("link")]
     public async Task<IActionResult> LinkTokenAsync(
         LinkMoodleTokenCommand command,

--- a/src/Kursa.API/Program.cs
+++ b/src/Kursa.API/Program.cs
@@ -38,10 +38,10 @@ try
             .AddJwtBearer(options =>
             {
                 options.Authority = builder.Configuration["Oidc:Authority"];
-                options.Audience = builder.Configuration["Oidc:ClientId"];
                 options.RequireHttpsMetadata = builder.Configuration.GetValue("Oidc:RequireHttpsMetadata", true);
                 options.TokenValidationParameters.NameClaimType = "name";
                 options.TokenValidationParameters.RoleClaimType = "role";
+                options.TokenValidationParameters.ValidateAudience = false;
             });
     }
 

--- a/src/Kursa.Application/Features/Moodle/Commands/ValidateMoodleCredentials.cs
+++ b/src/Kursa.Application/Features/Moodle/Commands/ValidateMoodleCredentials.cs
@@ -1,0 +1,30 @@
+using Kursa.Application.Common.Interfaces;
+using Kursa.Application.Common.Models;
+using FluentValidation;
+using Mediator;
+
+namespace Kursa.Application.Features.Moodle.Commands;
+
+public sealed record ValidateMoodleCredentialsCommand(string Username, string Password) : ICommand<Result>;
+
+public sealed class ValidateMoodleCredentialsValidator : AbstractValidator<ValidateMoodleCredentialsCommand>
+{
+    public ValidateMoodleCredentialsValidator()
+    {
+        RuleFor(x => x.Username).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.Password).NotEmpty().MaximumLength(512);
+    }
+}
+
+public sealed class ValidateMoodleCredentialsHandler(
+    IMoodleService moodleService) : ICommandHandler<ValidateMoodleCredentialsCommand, Result>
+{
+    public async ValueTask<Result> Handle(ValidateMoodleCredentialsCommand request, CancellationToken cancellationToken)
+    {
+        var token = await moodleService.GetTokenAsync(request.Username, request.Password, cancellationToken);
+
+        return token is not null
+            ? Result.Success()
+            : Result.Failure("Invalid Moodle credentials.");
+    }
+}

--- a/src/Kursa.Frontend/src/app/app.routes.ts
+++ b/src/Kursa.Frontend/src/app/app.routes.ts
@@ -1,7 +1,6 @@
 import { Routes } from '@angular/router';
 import { ShellComponent } from './layout/shell.component';
 import { authGuard } from './core/guards/auth.guard';
-import { onboardingGuard } from './core/guards/onboarding.guard';
 
 export const routes: Routes = [
   {
@@ -23,7 +22,7 @@ export const routes: Routes = [
   {
     path: '',
     component: ShellComponent,
-    canActivate: [authGuard, onboardingGuard],
+    canActivate: [authGuard],
     children: [
       {
         path: '',

--- a/src/Kursa.Frontend/src/app/core/guards/auth.guard.ts
+++ b/src/Kursa.Frontend/src/app/core/guards/auth.guard.ts
@@ -6,11 +6,11 @@ export const authGuard: CanActivateFn = () => {
   const oauthService = inject(OAuthService);
   const router = inject(Router);
 
-  if (oauthService.hasValidAccessToken()) {
+  // Check both that the library considers the token valid AND that a token actually exists
+  const token = oauthService.getAccessToken();
+  if (token && oauthService.hasValidAccessToken()) {
     return true;
   }
 
-  // Save attempted URL for redirect after login
-  oauthService.initCodeFlow();
   return router.createUrlTree(['/login']);
 };

--- a/src/Kursa.Frontend/src/app/core/guards/onboarding.guard.ts
+++ b/src/Kursa.Frontend/src/app/core/guards/onboarding.guard.ts
@@ -14,6 +14,6 @@ export const onboardingGuard: CanActivateFn = () => {
 
   return authService.getCurrentUser().pipe(
     map((user) => (user.onboardingCompleted ? true : router.createUrlTree(['/onboarding']))),
-    catchError(() => of(true)),
+    catchError(() => of(router.createUrlTree(['/onboarding']))),
   );
 };

--- a/src/Kursa.Frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/Kursa.Frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,18 +1,36 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { OAuthService } from 'angular-oauth2-oidc';
+import { catchError, throwError } from 'rxjs';
+
+let isLoggingOut = false;
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const oauthService = inject(OAuthService);
+  const router = inject(Router);
   const token = oauthService.getAccessToken();
 
-  if (token && req.url.startsWith('/api')) {
-    return next(
-      req.clone({
-        setHeaders: { Authorization: `Bearer ${token}` },
-      }),
-    );
-  }
+  const request = token && req.url.startsWith('/api')
+    ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+    : req;
 
-  return next(req);
+  return next(request).pipe(
+    catchError((error) => {
+      if (error.status === 401 && req.url.startsWith('/api') && !isLoggingOut) {
+        isLoggingOut = true;
+        // Clear local tokens without triggering OIDC RP-Initiated Logout
+        sessionStorage.clear();
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('id_token');
+        localStorage.removeItem('refresh_token');
+        localStorage.removeItem('nonce');
+        localStorage.removeItem('PKCE_verifier');
+        router.navigate(['/login'], { queryParams: { expired: 'true' } }).then(() => {
+          isLoggingOut = false;
+        });
+      }
+      return throwError(() => error);
+    }),
+  );
 };

--- a/src/Kursa.Frontend/src/app/core/services/auth.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/auth.service.ts
@@ -84,6 +84,13 @@ export class AuthService {
       .pipe(tap((user) => this._profile.set(user)));
   }
 
+  /** Creates user in DB + marks onboarding complete. */
+  register(): Observable<UserProfile> {
+    return this.http
+      .post<UserProfile>('/api/auth/register', {})
+      .pipe(tap((user) => this._profile.set(user)));
+  }
+
   completeOnboarding(): Observable<void> {
     return this.http.post<void>('/api/users/me/onboarding/complete', {});
   }

--- a/src/Kursa.Frontend/src/app/core/services/moodle.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/moodle.service.ts
@@ -61,6 +61,10 @@ export class MoodleService {
     return this.http.get<MoodleConnectionStatus>(`${this.baseUrl}/status`);
   }
 
+  validateCredentials(username: string, password: string): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/validate`, { username, password });
+  }
+
   linkMoodle(username: string, password: string): Observable<void> {
     return this.http.post<void>(`${this.baseUrl}/link`, { username, password });
   }

--- a/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
+++ b/src/Kursa.Frontend/src/app/features/callback/callback.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { AuthService } from '../../core/services/auth.service';
 import { firstValueFrom } from 'rxjs';
@@ -40,19 +41,27 @@ export class CallbackComponent implements OnInit {
 
   async ngOnInit(): Promise<void> {
     const success = await this.authService.handleCallback();
-    if (success) {
-      try {
-        const user = await firstValueFrom(this.authService.getCurrentUser());
-        await this.router.navigate([user.onboardingCompleted ? '/dashboard' : '/onboarding']);
-      } catch {
-        await this.router.navigate(['/dashboard']);
-      }
-    } else {
+    if (!success) {
       this.error.set(
         'Sign-in failed. Make sure the Pocket ID client has redirect URL ' +
           window.location.origin +
           '/callback registered, and that Public client + PKCE are enabled.',
       );
+      return;
+    }
+
+    try {
+      // Check if user already exists in DB
+      await firstValueFrom(this.authService.getCurrentUser());
+      await this.router.navigate(['/dashboard']);
+    } catch (err) {
+      if (err instanceof HttpErrorResponse && err.status === 404) {
+        // User not registered yet → onboarding
+        await this.router.navigate(['/onboarding']);
+      } else {
+        // Other error — still go to onboarding as safe default
+        await this.router.navigate(['/onboarding']);
+      }
     }
   }
 

--- a/src/Kursa.Frontend/src/app/features/login/login.component.ts
+++ b/src/Kursa.Frontend/src/app/features/login/login.component.ts
@@ -1,9 +1,12 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { HlmButton } from '@spartan-ng/helm/button';
 import { AuthService } from '../../core/services/auth.service';
 
 @Component({
   selector: 'app-login',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [HlmButton],
   template: `
     <div class="flex min-h-screen items-center justify-center bg-background">
       <div class="text-center">
@@ -11,16 +14,21 @@ import { AuthService } from '../../core/services/auth.service';
           <img src="favicon.ico" alt="Kursa" class="h-10 w-10" />
           <span class="text-3xl font-bold text-foreground">Kursa</span>
         </div>
-        <p class="mb-8 text-muted-foreground">Signing you in…</p>
-        <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto"></div>
+
+        @if (isExpired) {
+          <p class="mb-4 text-sm text-destructive">Your session has expired. Please sign in again.</p>
+        } @else {
+          <p class="mb-4 text-muted-foreground">Sign in to access your courses and study tools.</p>
+        }
+
+        <button hlmBtn (click)="authService.login()">Sign in with Pocket ID</button>
       </div>
     </div>
   `,
 })
-export class LoginComponent implements OnInit {
-  private readonly authService = inject(AuthService);
+export class LoginComponent {
+  readonly authService = inject(AuthService);
+  private readonly route = inject(ActivatedRoute);
 
-  ngOnInit(): void {
-    this.authService.login();
-  }
+  readonly isExpired = this.route.snapshot.queryParamMap.get('expired') === 'true';
 }

--- a/src/Kursa.Frontend/src/app/features/onboarding/onboarding.component.ts
+++ b/src/Kursa.Frontend/src/app/features/onboarding/onboarding.component.ts
@@ -127,15 +127,19 @@ import { MoodleService } from '../../core/services/moodle.service';
             }
 
             <div class="flex items-center gap-3">
-              @if (currentStep() < steps.length - 1) {
+              @if (currentStep() < steps.length - 1 && currentStep() !== 1) {
                 <button hlmBtn variant="ghost" (click)="skip()">
                   Skip
                 </button>
               }
 
               @if (currentStep() < steps.length - 1) {
-                <button hlmBtn (click)="next()">
-                  {{ currentStep() === 1 && moodleUsername && moodlePassword ? 'Connect & Continue' : 'Continue' }}
+                <button hlmBtn (click)="next()" [disabled]="moodleValidating() || (currentStep() === 1 && (!moodleUsername || !moodlePassword))">
+                  @if (moodleValidating()) {
+                    Validating…
+                  } @else {
+                    {{ currentStep() === 1 ? 'Connect & Continue' : 'Continue' }}
+                  }
                 </button>
               } @else {
                 <button hlmBtn class="px-6" (click)="finish()">
@@ -163,20 +167,25 @@ export class OnboardingComponent implements OnInit {
   moodlePassword = '';
   selectedTheme = 'dark';
 
+  readonly moodleValidating = signal(false);
+
   ngOnInit(): void {
-    // Ensure the user record exists in the DB before any actions (e.g. Moodle linking)
-    this.authService.getCurrentUser().subscribe();
+    // Nothing to do — user record is created only on finish (register)
   }
 
   next(): void {
+    // On Moodle step, validate credentials before proceeding
     if (this.currentStep() === 1 && this.moodleUsername && this.moodlePassword) {
       this.moodleLinkError.set(null);
-      this.moodleService.linkMoodle(this.moodleUsername, this.moodlePassword).subscribe({
+      this.moodleValidating.set(true);
+      this.moodleService.validateCredentials(this.moodleUsername, this.moodlePassword).subscribe({
         next: () => {
+          this.moodleValidating.set(false);
           this.moodleLinkSuccess.set(true);
           this.currentStep.update((s) => s + 1);
         },
         error: () => {
+          this.moodleValidating.set(false);
           this.moodleLinkError.set('Invalid credentials. Please check and try again.');
         },
       });
@@ -199,12 +208,20 @@ export class OnboardingComponent implements OnInit {
   }
 
   finish(): void {
-    this.authService.completeOnboarding().subscribe({
+    // Register creates the user in DB + marks onboarding complete
+    this.authService.register().subscribe({
       next: () => {
-        this.router.navigate(['/dashboard']);
+        // Now link Moodle if credentials were provided
+        if (this.moodleUsername && this.moodlePassword) {
+          this.moodleService.linkMoodle(this.moodleUsername, this.moodlePassword).subscribe({
+            next: () => this.router.navigate(['/dashboard']),
+            error: () => this.router.navigate(['/dashboard']),
+          });
+        } else {
+          this.router.navigate(['/dashboard']);
+        }
       },
       error: () => {
-        // Still navigate even if the API call fails — can retry later
         this.router.navigate(['/dashboard']);
       },
     });

--- a/src/Kursa.Frontend/src/app/layout/shell.component.ts
+++ b/src/Kursa.Frontend/src/app/layout/shell.component.ts
@@ -1,9 +1,11 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Router, RouterOutlet } from '@angular/router';
 import { SidebarComponent } from './sidebar.component';
 import { TopbarComponent } from './topbar.component';
 import { AiPanelComponent } from './ai-panel.component';
 import { AiContextService } from '../core/services/ai-context.service';
+import { AuthService } from '../core/services/auth.service';
 
 @Component({
   selector: 'app-shell',
@@ -29,9 +31,24 @@ import { AiContextService } from '../core/services/ai-context.service';
     </div>
   `,
 })
-export class ShellComponent {
+export class ShellComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
   readonly aiContext = inject(AiContextService);
   sidebarOpen = signal(true);
+
+  ngOnInit(): void {
+    // Load user profile; if 404 the user hasn't registered → send to onboarding
+    if (!this.authService.profile()) {
+      this.authService.getCurrentUser().subscribe({
+        error: (err: HttpErrorResponse) => {
+          if (err.status === 404) {
+            this.router.navigate(['/onboarding']);
+          }
+        },
+      });
+    }
+  }
 
   toggleSidebar() {
     this.sidebarOpen.update((v) => !v);


### PR DESCRIPTION
## Summary
- Disable JWT audience validation (Pocket ID doesn't set `aud` to client ID in access tokens)
- Split `/api/auth/me` (read-only) from `POST /api/auth/register` (creates user via OIDC userinfo)
- Add `POST /api/moodle/validate` for credential validation without requiring a DB user
- Add 401 interceptor with token cleanup, dedup flag, and login redirect
- Rework login page to show manual "Sign in" button (prevents auto-OIDC loops)
- Auth guard checks token exists, not just `hasValidAccessToken()`
- Callback routes new users to onboarding, existing users to dashboard
- Shell redirects to onboarding if user not registered (404 from `/api/auth/me`)
- Onboarding validates Moodle credentials before allowing continue

Closes #128

## Test plan
- [ ] Fresh DB: login → Pocket ID → callback → onboarding (not dashboard)
- [ ] Onboarding: invalid Moodle creds show error, valid creds proceed
- [ ] Finish onboarding: user created in DB, Moodle linked, redirected to dashboard
- [ ] Subsequent visits: goes directly to dashboard (user exists)
- [ ] Clear browser storage: redirected to login page with "Sign in" button
- [ ] Stale token: 401 interceptor clears tokens, shows login with "session expired"