### PR TITLE
fix(analytics): use client-side GroupBy for weekly study activity

### DIFF
--- a/src/Kursa.Application/Features/Analytics/GetAnalytics.cs
+++ b/src/Kursa.Application/Features/Analytics/GetAnalytics.cs
@@ -82,8 +82,12 @@ public sealed class GetAnalyticsHandler(
 
         // Weekly activity (last 7 days)
         DateTime weekAgo = now.Date.AddDays(-6);
-        List<StudyActivityDto> weeklyActivity = await dbContext.StudySessions
+        var recentSessions = await dbContext.StudySessions
             .Where(s => s.UserId == userId && s.Status == StudySessionStatus.Completed && s.CompletedAt != null && s.CompletedAt >= weekAgo)
+            .Select(s => new { s.CompletedAt, s.TotalDurationSeconds, s.CardsReviewed, s.QuizQuestionsAnswered })
+            .ToListAsync(cancellationToken);
+
+        List<StudyActivityDto> weeklyActivity = recentSessions
             .GroupBy(s => s.CompletedAt!.Value.Date)
             .Select(g => new StudyActivityDto(
                 g.Key,
@@ -91,7 +95,7 @@ public sealed class GetAnalyticsHandler(
                 g.Sum(s => s.CardsReviewed),
                 g.Sum(s => s.QuizQuestionsAnswered)))
             .OrderBy(a => a.Date)
-            .ToListAsync(cancellationToken);
+            .ToList();
 
         // Fill in missing days
         var filledActivity = new List<StudyActivityDto>();


### PR DESCRIPTION
## Summary
- EF Core cannot translate `GroupBy(s => s.CompletedAt.Value.Date)` to PostgreSQL SQL
- Fetch filtered sessions (max 7 days of data) to client first, then GroupBy in-memory
- Fixes the 500 error on `/api/analytics` that was spamming logs on every dashboard load

Closes #129, Closes #94

## Test plan
- [ ] Dashboard loads without 500 errors on `/api/analytics`
- [ ] Weekly activity chart shows correct data