### PR TITLE
feat(api): add AppController for version and OIDC config

### DIFF
--- a/src/Kursa.API/Controllers/AppController.cs
+++ b/src/Kursa.API/Controllers/AppController.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kursa.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AppController(IWebHostEnvironment environment, IConfiguration configuration) : ControllerBase
+{
+    /// <summary>
+    /// Returns application info: version, environment, and OIDC configuration.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult GetAppInfo()
+    {
+        string version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "unknown";
+
+        return Ok(new
+        {
+            Version = version != "unknown" ? $"v{version}" : version,
+            Environment = environment.IsProduction() ? "Production" : "Development",
+            IsHealthy = true,
+            Oidc = new
+            {
+                Issuer = configuration["Oidc:Authority"] ?? "",
+                ClientId = configuration["Oidc:ClientId"] ?? "",
+                RedirectUri = configuration["Oidc:RedirectUri"] ?? "/callback",
+                PostLogoutRedirectUri = configuration["Oidc:PostLogoutRedirectUri"] ?? "/",
+                Scope = configuration["Oidc:Scope"] ?? "openid profile email",
+            }
+        });
+    }
+}

--- a/src/Kursa.API/appsettings.json
+++ b/src/Kursa.API/appsettings.json
@@ -64,6 +64,9 @@
     "Authority": "https://auth.gaggao.com",
     "ClientId": "59793f91-bdda-4425-9e5c-1bdfd9baa5b6",
     "ClientSecret": "",
-    "RequireHttpsMetadata": true
+    "RequireHttpsMetadata": true,
+    "RedirectUri": "/callback",
+    "PostLogoutRedirectUri": "/",
+    "Scope": "openid profile email"
   }
 }


### PR DESCRIPTION
## Summary
- Added `GET /api/app` endpoint (unauthenticated) returning version, environment, health, and OIDC config
- Frontend can fetch OIDC settings dynamically instead of hardcoding in environment files
- Added `RedirectUri`, `PostLogoutRedirectUri`, `Scope` to Oidc config in appsettings.json
- Matches ArgonFetch AppController pattern

Closes #144

## Test plan
- [ ] `dotnet build` passes
- [ ] `GET /api/app` returns version, environment, and OIDC config
- [ ] Endpoint is accessible without authentication