### PR TITLE
refactor(frontend): simplify environments to match ArgonFetch

### DIFF
--- a/src/Kursa.Frontend/src/app/core/services/auth.service.ts
+++ b/src/Kursa.Frontend/src/app/core/services/auth.service.ts
@@ -1,9 +1,8 @@
 import { Injectable, inject, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, firstValueFrom } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { OAuthService, AuthConfig } from 'angular-oauth2-oidc';
-import { environment } from '../../../environments/environment';
 
 export interface UserProfile {
   id: string;
@@ -13,6 +12,19 @@ export interface UserProfile {
   role: string;
   onboardingCompleted: boolean;
   moodleConnected: boolean;
+}
+
+interface AppInfo {
+  version: string;
+  environment: string;
+  isHealthy: boolean;
+  oidc: {
+    issuer: string;
+    clientId: string;
+    redirectUri: string;
+    postLogoutRedirectUri: string;
+    scope: string;
+  };
 }
 
 @Injectable({ providedIn: 'root' })
@@ -26,15 +38,17 @@ export class AuthService {
   readonly isAuthenticated = computed(() => this.oauthService.hasValidAccessToken());
 
   async initialize(): Promise<void> {
+    const appInfo = await firstValueFrom(this.http.get<AppInfo>('/api/app'));
+
     const config: AuthConfig = {
-      issuer: environment.oidc.issuer,
-      clientId: environment.oidc.clientId,
-      redirectUri: environment.oidc.redirectUri,
-      postLogoutRedirectUri: environment.oidc.postLogoutRedirectUri,
-      scope: environment.oidc.scope,
-      responseType: environment.oidc.responseType,
-      showDebugInformation: environment.oidc.showDebugInformation,
-      strictDiscoveryDocumentValidation: environment.oidc.strictDiscoveryDocumentValidation,
+      issuer: appInfo.oidc.issuer,
+      clientId: appInfo.oidc.clientId,
+      redirectUri: appInfo.oidc.redirectUri,
+      postLogoutRedirectUri: appInfo.oidc.postLogoutRedirectUri,
+      scope: appInfo.oidc.scope,
+      responseType: 'code',
+      showDebugInformation: appInfo.environment !== 'Production',
+      strictDiscoveryDocumentValidation: false,
       useSilentRefresh: false,
       clearHashAfterLogin: true,
     };

--- a/src/Kursa.Frontend/src/environments/environment.development.ts
+++ b/src/Kursa.Frontend/src/environments/environment.development.ts
@@ -1,14 +1,4 @@
 export const environment = {
   production: false,
   apiBaseUrl: 'http://localhost:5024',
-  oidc: {
-    issuer: 'https://auth.gaggao.com',
-    clientId: '59793f91-bdda-4425-9e5c-1bdfd9baa5b6',
-    redirectUri: 'http://localhost:4200/callback',
-    postLogoutRedirectUri: 'http://localhost:4200',
-    scope: 'openid profile email',
-    responseType: 'code',
-    showDebugInformation: true,
-    strictDiscoveryDocumentValidation: false,
-  },
 };

--- a/src/Kursa.Frontend/src/environments/environment.ts
+++ b/src/Kursa.Frontend/src/environments/environment.ts
@@ -1,14 +1,4 @@
 export const environment = {
   production: true,
   apiBaseUrl: window.location.origin,
-  oidc: {
-    issuer: 'https://auth.gaggao.com',
-    clientId: '59793f91-bdda-4425-9e5c-1bdfd9baa5b6',
-    redirectUri: '/callback',
-    postLogoutRedirectUri: '/',
-    scope: 'openid profile email',
-    responseType: 'code',
-    showDebugInformation: false,
-    strictDiscoveryDocumentValidation: false,
-  },
 };


### PR DESCRIPTION
## Summary
- Removed hardcoded OIDC config from environment files — now just `production` + `apiBaseUrl`
- Auth service fetches OIDC config from `GET /api/app` at startup instead
- Environments now match ArgonFetch pattern exactly

Closes #146

## Test plan
- [ ] `bun run build` passes
- [ ] Auth service initializes correctly by fetching config from `/api/app`
- [ ] Login flow still works with Pocket ID